### PR TITLE
Feat/market snapshots

### DIFF
--- a/GraphNodeDockerfile
+++ b/GraphNodeDockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.67
+
+RUN apt-get update && apt-get install git -y
+
+RUN git clone https://github.com/graphprotocol/graph-node
+
+RUN apt-get install protobuf-compiler clang libpq-dev libssl-dev pkg-config -y
+
+WORKDIR /graph-node
+
+RUN \
+  cargo build --release
+
+CMD cargo run --release -- --postgres-url postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/graph-node --ethereum-rpc ${NODE_NETWORK}:full:${NODE_RPC_URL} --ipfs ${IPFS_HOST}
+

--- a/GraphNodeDockerfile
+++ b/GraphNodeDockerfile
@@ -11,5 +11,5 @@ WORKDIR /graph-node
 RUN \
   cargo build --release
 
-CMD cargo run --release -- --postgres-url postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/graph-node --ethereum-rpc ${NODE_NETWORK}:full:${NODE_RPC_URL} --ipfs ${IPFS_HOST}
+CMD cargo run --release -- --postgres-url postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/graph-node --ethereum-rpc ${NODE_RPC_CONFIG} --ipfs ${IPFS_HOST}
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Benqi-subgraph
 
+### Prerequisites:
+- Graph-cli: https://github.com/graphprotocol/graph-tooling/tree/main/packages/cli
+
+#### To run a graph-node on your local computer
+- Graph-node: https://github.com/graphprotocol/graph-node
+
+#### To run a graph-node on docker
+- Docker: https://docs.docker.com/engine/
+- Setup on host machine: https://github.com/fmedv/docker-go-ipfs#setup-pre-configuration
+
+Sometimes the graph-node process starts up faster than the ipfs, so it's safer to run 2 separate commands:
+`docker-compose up -d graph-db ipfs`
+`docker-compose up graph-node`
+
 ### Commands:
 
 generate types:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.7"
+services:
+  graph-db:
+    image: postgres:15
+    restart: always
+    volumes:
+      - ../db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432" #console
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgrespassword
+      POSTGRES_DB: graph-node
+      POSTGRES_INITDB_ARGS: "--locale-provider=icu --icu-locale=C"
+      LC_ALL: "C"
+      LC_CTYPE: "C"
+    command: ["postgres", "-c", "log_statement=all"]
+  ipfs:
+    image: ipfs/kubo:master-2023-02-02-14649aa
+    restart: always
+    volumes:
+      - ../ipfs/staging:/export
+      - ../ipfs/data:/data/ipfs
+    ports:
+      - "4001:4001"
+      - "4001:4001/udp"
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:5001:5001"
+  graph-node:
+    build: 
+      context: .
+      dockerfile: GraphNodeDockerfile
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgrespassword
+      POSTGRES_HOST: graph-db:5432
+      IPFS_HOST: ipfs:5001
+      NODE_NETWORK: avalanche
+      NODE_RPC_URL: http://avalanche05.ct.romenet.io:9650/ext/bc/C/rpc
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+      - "8020:8020"
+      - "8030:8030"
+      - "8040:8040"
+    depends_on:
+      - graph-db
+      - ipfs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       POSTGRES_HOST: graph-db:5432
       IPFS_HOST: ipfs:5001
       NODE_NETWORK: avalanche
-      NODE_RPC_URL: http://avalanche05.ct.romenet.io:9650/ext/bc/C/rpc
+      NODE_RPC_CONFIG: avalanche:archive:http://avalanche05.ct.romenet.io:9650/ext/bc/C/rpc
     ports:
       - "8000:8000"
       - "8001:8001"

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "benqi-v1-avalanche",
   "license": "MIT",
   "scripts": {
-    "codegen": "npx graph codegen --output-dir src/types/",
-    "build": "npx graph build",
+    "codegen": "graph codegen --output-dir src/types/",
+    "build": "graph build",
     "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ token-terminal/benqi-v1-avalanche",
     "create-local": "graph create --node http://localhost:8020/ token-terminal/benqi-v1-avalanche",
     "remove-local": "graph remove --node http://localhost:8020/ token-terminal/benqi-v1-avalanche",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 token-terminal/benqi-v1-avalanche"
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 token-terminal/benqi-v1-avalanche",
+    "test": "graph test"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.20.1",

--- a/schema.graphql
+++ b/schema.graphql
@@ -15,10 +15,8 @@ type Comptroller @entity {
   address: Bytes!
 }
 
-"""
-Market stores all high level variables for a cToken market
-"""
-type Market @entity {
+interface MarketInfo {
+  
   #Fields that match compounds API
   "Yearly borrow rate. With 2102400 blocks per year"
   borrowRate: BigDecimal!
@@ -30,28 +28,20 @@ type Market @entity {
   exchangeRate: BigDecimal!
   "Address of the interest rate model"
   interestRateModelAddress: Bytes
-  "Name of the cToken"
-  name: String!
   "Reserves stored in the contract"
   reserves: BigDecimal
   "Yearly supply rate. With 2104400 blocks per year"
   supplyRate: BigDecimal
-  "CToken symbol"
-  symbol: String!
-  "CToken address"
-  id: ID!
   "Borrows in the market"
   totalBorrows: BigDecimal!
   "CToken supply. CTokens have 8 decimals"
   totalSupply: BigDecimal!
-  "Underlying token address"
-  underlyingAddress: Bytes!
-  "Underlying token name"
-  underlyingName: String!
+  "Number of users holding market tokens"
+  suppliersCount: Int!
+  "Number of users with pending borrows"
+  borrowersCount: Int!
   "Underlying price of token in ETH (ex. 0.007 DAI)"
   underlyingPrice: BigDecimal!
-  "Underlying token symbol"
-  underlyingSymbol: String!
 
   # Fields that are not in compounds api
   "Block the market is updated to"
@@ -64,16 +54,236 @@ type Market @entity {
   reserveFactor: BigDecimal!
   "Underlying token price in USD"
   underlyingPriceUSD: BigDecimal!
-  "Underlying token decimal length"
-  underlyingDecimals: Int!
 
   # @yhayun - added specifically for benqi:
+  "Total rewards accrued per reward type. The array index is the same as the reward type index and the unit is that of the reward type"
+  totalRewardsDistributed: [BigDecimal!]!
   "Total interest accrued"
   totalFeesGenerated: BigDecimal!
   "The part of total fees that goes to the protocol"
   totalProtocolFeesGenerated: BigDecimal!
+}
+
+"""
+Market stores all high level variables for a cToken market
+"""
+type Market implements MarketInfo @entity {
+  "CToken address"
+  id: ID!
+  
+  ### INTERFACE FIELDS
+  #Fields that match compounds API
+  "Yearly borrow rate. With 2102400 blocks per year"
+  borrowRate: BigDecimal!
+  "The cToken contract balance of ERC20 or ETH"
+  cash: BigDecimal!
+  "Collateral factor determining how much one can borrow"
+  collateralFactor: BigDecimal!
+  "Exchange rate of tokens / cTokens"
+  exchangeRate: BigDecimal!
+  "Address of the interest rate model"
+  interestRateModelAddress: Bytes
+  "Reserves stored in the contract"
+  reserves: BigDecimal
+  "Yearly supply rate. With 2104400 blocks per year"
+  supplyRate: BigDecimal
+  "Borrows in the market"
+  totalBorrows: BigDecimal!
+  "CToken supply. CTokens have 8 decimals"
+  totalSupply: BigDecimal!
+  "Number of users holding market tokens"
+  suppliersCount: Int!
+  "Number of users with pending borrows"
+  borrowersCount: Int!
+  "Underlying price of token in ETH (ex. 0.007 DAI)"
+  underlyingPrice: BigDecimal!
+
+  # Fields that are not in compounds api
+  "Block the market is updated to"
+  accrualBlockNumber: Int
+  "Timestamp the market was most recently updated"
+  blockTimestamp: Int!
+  "The history of the markets borrow index return (Think S&P 500)"
+  borrowIndex: BigDecimal!
+  "The factor determining interest that goes to reserves"
+  reserveFactor: BigDecimal!
+  "Underlying token price in USD"
+  underlyingPriceUSD: BigDecimal!
+
+  # @yhayun - added specifically for benqi:
+  "Total rewards accrued per reward type. The array index is the same as the reward type index and the unit is that of the reward type"
+  totalRewardsDistributed: [BigDecimal!]!
+  "Total interest accrued"
+  totalFeesGenerated: BigDecimal!
+  "The part of total fees that goes to the protocol"
+  totalProtocolFeesGenerated: BigDecimal!
+  
+  ### END OF INTERFACE FIELDS
+
+  #Fields that match compounds API
+  "Name of the cToken"
+  name: String!
+  "CToken symbol"
+  symbol: String!
+  "Underlying token address"
+  underlyingAddress: Bytes!
+  "Underlying token name"
+  underlyingName: String!
+  "Underlying token symbol"
+  underlyingSymbol: String!
+
+  # Fields that are not in compounds api
+  "Underlying token decimal length"
+  underlyingDecimals: Int!
+
+  # @yhayun - added specifically for benqi:
   "Underlying token"
   denomination: Token
+  """Since CTokenTransfer uses the Seized market as the main market, 
+  this field enables the search of liquidation events where this is the market being repaid"""
+  repaymentsThroughLiquidation: [LiquidationEvent!]! @derivedFrom(field: "repayMarket")
+  "All cTokenTransfer events which the token of this market is being transfered (i.e. LiquidationEvents only appear on the Collateral market)"
+  cTokenTransfers: [CTokenTransfer!]! @derivedFrom(field: "market")
+  "Transfers of the Underlying Token where no market token is being transfered (i.e. Borrow and Repay)"
+  underlyingTransfer: [UnderlyingTransfer!]! @derivedFrom(field: "market")
+
+  hourlySnapshots: [MarketHourlySnapshot!]! @derivedFrom(field: "market")
+  dailySnapshots: [MarketDailySnapshot!]! @derivedFrom(field: "market")
+}
+
+"""
+Saves the historical values in the Market over time for every beginning of hour in UTC.
+Basically a copy of the market values in that particular moment
+"""
+type MarketHourlySnapshot implements MarketInfo @entity {
+  "The id is marketId-timestamp"
+  id: ID!
+  market: Market!
+  "UTC timestamp for the beginning of the hour (ex.: timestamp for 01:00:00, 14:00:00, ...)"
+  timestamp: BigInt!
+  lastBlockNumber: BigInt!
+  lastBlockHash: String!
+
+  ### INTERFACE FIELDS
+  #Fields that match compounds API
+  "Yearly borrow rate. With 2102400 blocks per year"
+  borrowRate: BigDecimal!
+  "The cToken contract balance of ERC20 or ETH"
+  cash: BigDecimal!
+  "Collateral factor determining how much one can borrow"
+  collateralFactor: BigDecimal!
+  "Exchange rate of tokens / cTokens"
+  exchangeRate: BigDecimal!
+  "Address of the interest rate model"
+  interestRateModelAddress: Bytes
+  "Reserves stored in the contract"
+  reserves: BigDecimal
+  "Yearly supply rate. With 2104400 blocks per year"
+  supplyRate: BigDecimal
+  "Borrows in the market"
+  totalBorrows: BigDecimal!
+  "CToken supply. CTokens have 8 decimals"
+  totalSupply: BigDecimal!
+  "Number of users holding market tokens"
+  suppliersCount: Int!
+  "Number of users with pending borrows"
+  borrowersCount: Int!
+  "Underlying price of token in ETH (ex. 0.007 DAI)"
+  underlyingPrice: BigDecimal!
+
+  # Fields that are not in compounds api
+  "Block the market is updated to"
+  accrualBlockNumber: Int
+  "Timestamp the market was most recently updated"
+  blockTimestamp: Int!
+  "The history of the markets borrow index return (Think S&P 500)"
+  borrowIndex: BigDecimal!
+  "The factor determining interest that goes to reserves"
+  reserveFactor: BigDecimal!
+  "Underlying token price in USD"
+  underlyingPriceUSD: BigDecimal!
+
+  # @yhayun - added specifically for benqi:
+  "Total rewards accrued per reward type. The array index is the same as the reward type index and the unit is that of the reward type"
+  totalRewardsDistributed: [BigDecimal!]!
+  "Total interest accrued"
+  totalFeesGenerated: BigDecimal!
+  "The part of total fees that goes to the protocol"
+  totalProtocolFeesGenerated: BigDecimal!
+  
+  ### END OF INTERFACE FIELDS
+}
+
+"""
+Saves the historical values in the Market over time for every beginning of a day in UTC.
+Basically a copy of the market values in that particular moment
+"""
+type MarketDailySnapshot implements MarketInfo @entity {
+  "The id is marketId-timestamp"
+  id: ID!
+  market: Market!
+  "UTC timestamp for the beginning of the day (ex.: timestamp for Day 1 00:00:00, Day 2 00:00:00, ...)"
+  timestamp: BigInt!
+  lastBlockNumber: BigInt!
+  lastBlockHash: String!
+
+  ### INTERFACE FIELDS
+  #Fields that match compounds API
+  "Yearly borrow rate. With 2102400 blocks per year"
+  borrowRate: BigDecimal!
+  "The cToken contract balance of ERC20 or ETH"
+  cash: BigDecimal!
+  "Collateral factor determining how much one can borrow"
+  collateralFactor: BigDecimal!
+  "Exchange rate of tokens / cTokens"
+  exchangeRate: BigDecimal!
+  "Address of the interest rate model"
+  interestRateModelAddress: Bytes
+  "Reserves stored in the contract"
+  reserves: BigDecimal
+  "Yearly supply rate. With 2104400 blocks per year"
+  supplyRate: BigDecimal
+  "Borrows in the market"
+  totalBorrows: BigDecimal!
+  "CToken supply. CTokens have 8 decimals"
+  totalSupply: BigDecimal!
+  "Number of users holding market tokens"
+  suppliersCount: Int!
+  "Number of users with pending borrows"
+  borrowersCount: Int!
+  "Underlying price of token in ETH (ex. 0.007 DAI)"
+  underlyingPrice: BigDecimal!
+
+  # Fields that are not in compounds api
+  "Block the market is updated to"
+  accrualBlockNumber: Int
+  "Timestamp the market was most recently updated"
+  blockTimestamp: Int!
+  "The history of the markets borrow index return (Think S&P 500)"
+  borrowIndex: BigDecimal!
+  "The factor determining interest that goes to reserves"
+  reserveFactor: BigDecimal!
+  "Underlying token price in USD"
+  underlyingPriceUSD: BigDecimal!
+
+  # @yhayun - added specifically for benqi:
+  "Total rewards accrued per reward type. The array index is the same as the reward type index and the unit is that of the reward type"
+  totalRewardsDistributed: [BigDecimal!]!
+  "Total interest accrued"
+  totalFeesGenerated: BigDecimal!
+  "The part of total fees that goes to the protocol"
+  totalProtocolFeesGenerated: BigDecimal!
+  
+  ### END OF INTERFACE FIELDS
+}
+
+type AccountSnapshot @entity(immutable: true) {
+  id: ID!
+  account: Account!
+  market: Market!
+  blockNumber: Int!
+  supply_amount: BigDecimal!
+  borrow_amount: BigDecimal!
 }
 
 """
@@ -176,12 +386,24 @@ type AccountCTokenTransaction @entity {
 }
 
 """
+Types of CTokenTransfers
+"""
+enum CTokenTransferType {
+  Transfer
+  Mint
+  Redeem
+  Liquidation
+}
+
+"""
 An interface for a transfer of any cToken. TransferEvent, MintEvent,
 RedeemEvent, and LiquidationEvent all use this interface
 """
 interface CTokenTransfer {
   "Transaction hash concatenated with log index"
   id: ID!
+  "Type of the specific transfer"
+  type: CTokenTransferType!
   "cTokens transferred"
   amount: BigDecimal!
   "Account that received tokens"
@@ -192,17 +414,19 @@ interface CTokenTransfer {
   blockNumber: Int!
   "Block time"
   blockTime: Int!
-  "Symbol of the cToken transferred"
-  cTokenSymbol: String!
+  "The cToken transferred"
+  market: Market!
 }
 
 """
 TransferEvent will be stored for every mint, redeem, liquidation, and any normal
 transfer between two accounts.
 """
-type TransferEvent implements CTokenTransfer @entity {
+type TransferEvent implements CTokenTransfer @entity(immutable: true) {
   "Transaction hash concatenated with log index"
   id: ID!
+  "Type of the specific transfer"
+  type: CTokenTransferType!
   "cTokens transferred"
   amount: BigDecimal!
   "Account that received tokens"
@@ -213,17 +437,19 @@ type TransferEvent implements CTokenTransfer @entity {
   blockNumber: Int!
   "Block time"
   blockTime: Int!
-  "Symbol of the cToken transferred"
-  cTokenSymbol: String!
+  "The cToken transferred"
+  market: Market!
 }
 
 """
 MintEvent stores information for mints. From address will always be a cToken
 market address
 """
-type MintEvent implements CTokenTransfer @entity {
+type MintEvent implements CTokenTransfer @entity(immutable: true) {
   "Transaction hash concatenated with log index"
   id: ID!
+  "Type of the specific transfer"
+  type: CTokenTransferType!
   "cTokens transferred"
   amount: BigDecimal!
   "Account that received tokens (minter)"
@@ -234,8 +460,8 @@ type MintEvent implements CTokenTransfer @entity {
   blockNumber: Int!
   "Block time"
   blockTime: Int!
-  "Symbol of the cToken transferred"
-  cTokenSymbol: String!
+  "The cToken transferred"
+  market: Market!
   "Underlying token amount transferred"
   underlyingAmount: BigDecimal
 }
@@ -244,9 +470,11 @@ type MintEvent implements CTokenTransfer @entity {
 RedeemEvent stores information for redeems. To address will always be a
 cToken market address
 """
-type RedeemEvent implements CTokenTransfer @entity {
+type RedeemEvent implements CTokenTransfer @entity(immutable: true) {
   "Transaction hash concatenated with log index"
   id: ID!
+  "Type of the specific transfer"
+  type: CTokenTransferType!
   "cTokens transferred"
   amount: BigDecimal!
   "Account that received tokens (CToken contract)"
@@ -257,8 +485,8 @@ type RedeemEvent implements CTokenTransfer @entity {
   blockNumber: Int!
   "Block time"
   blockTime: Int!
-  "Symbol of the cToken transferred"
-  cTokenSymbol: String!
+  "The cToken transferred"
+  market: Market!
   "Underlying token amount transferred"
   underlyingAmount: BigDecimal
 }
@@ -267,9 +495,11 @@ type RedeemEvent implements CTokenTransfer @entity {
 LiquidationEvent stores information for liquidations. The event is emitted from
 the cToken market address.
 """
-type LiquidationEvent implements CTokenTransfer @entity {
+type LiquidationEvent implements CTokenTransfer @entity(immutable: true) {
   "Transaction hash concatenated with log index"
   id: ID!
+  "Type of the specific transfer"
+  type: CTokenTransferType!
   "cTokens seized"
   amount: BigDecimal!
   "Liquidator receiving tokens"
@@ -280,12 +510,22 @@ type LiquidationEvent implements CTokenTransfer @entity {
   blockNumber: Int!
   "Block time"
   blockTime: Int!
-  "cToken that was sezied as collateral"
-  cTokenSymbol: String!
+  "cToken that was seized as collateral"
+  market: Market!
+  "The cToken that was repaid during this liquidation"
+  repayMarket: Market!
   "Symbol of the underlying asset repaid through liquidation"
   underlyingSymbol: String!
   "Underlying cToken amount that was repaid by liquidator"
   underlyingRepayAmount: BigDecimal!
+}
+
+"""
+Types of UnderlyingTransfer
+"""
+enum UnderlyingTransferType {
+  Borrow
+  Repay
 }
 
 """
@@ -295,6 +535,10 @@ and repays
 interface UnderlyingTransfer {
   "Transaction hash concatenated with log index"
   id: ID!
+  "Specific type of the implementation"
+  type: UnderlyingTransferType!
+  "The cToken where the lending happened"
+  market: Market!
   "Amount of underlying borrowed"
   amount: BigDecimal!
   "Total borrows of this asset the account has"
@@ -312,9 +556,13 @@ interface UnderlyingTransfer {
 """
 BorrowEvent stores information for borrows
 """
-type BorrowEvent implements UnderlyingTransfer @entity {
+type BorrowEvent implements UnderlyingTransfer @entity(immutable: true) {
   "Transaction hash concatenated with log index"
   id: ID!
+  "Market from which the token is being borrowed"
+  market: Market!
+  "Specific type of the implementation"
+  type: UnderlyingTransferType!
   "Amount of underlying borrowed"
   amount: BigDecimal!
   "Total borrows of this asset the account has"
@@ -333,9 +581,13 @@ type BorrowEvent implements UnderlyingTransfer @entity {
 RepayEvent stores information for repays. Payer is not always the same as
 borrower, such as in the event of a Liquidation
 """
-type RepayEvent implements UnderlyingTransfer @entity {
+type RepayEvent implements UnderlyingTransfer @entity(immutable: true) {
   "Transaction hash concatenated with log index"
   id: ID!
+  "Market to which the token is being repaid"
+  market: Market!
+  "Specific type of the implementation"
+  type: UnderlyingTransferType!
   "Amount of underlying repaid"
   amount: BigDecimal!
   "Total borrows of this asset the account has"
@@ -352,7 +604,7 @@ type RepayEvent implements UnderlyingTransfer @entity {
   payer: Bytes!
 }
 
-type Token @entity {
+type Token @entity(immutable: true) {
   "Token address"
   id: ID!
 
@@ -360,14 +612,14 @@ type Token @entity {
   address: Bytes!
 
   "Token name"
-  name: String!
+  name: String
 
   "Token symbol"
-  symbol: String!
+  symbol: String
 
   "Token decimals"
-  decimals: Int!
+  decimals: Int
 
   "Token's total supply"
-  totalSupply: BigInt!
+  totalSupply: BigInt
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -45,9 +45,9 @@ interface MarketInfo {
 
   # Fields that are not in compounds api
   "Block the market is updated to"
-  accrualBlockNumber: Int
+  accrualBlockNumber: BigInt
   "Timestamp the market was most recently updated"
-  blockTimestamp: Int!
+  blockTimestamp: BigInt!
   "The history of the markets borrow index return (Think S&P 500)"
   borrowIndex: BigDecimal!
   "The factor determining interest that goes to reserves"
@@ -100,9 +100,9 @@ type Market implements MarketInfo @entity {
 
   # Fields that are not in compounds api
   "Block the market is updated to"
-  accrualBlockNumber: Int
+  accrualBlockNumber: BigInt
   "Timestamp the market was most recently updated"
-  blockTimestamp: Int!
+  blockTimestamp: BigInt!
   "The history of the markets borrow index return (Think S&P 500)"
   borrowIndex: BigDecimal!
   "The factor determining interest that goes to reserves"
@@ -193,9 +193,9 @@ type MarketHourlySnapshot implements MarketInfo @entity {
 
   # Fields that are not in compounds api
   "Block the market is updated to"
-  accrualBlockNumber: Int
+  accrualBlockNumber: BigInt
   "Timestamp the market was most recently updated"
-  blockTimestamp: Int!
+  blockTimestamp: BigInt!
   "The history of the markets borrow index return (Think S&P 500)"
   borrowIndex: BigDecimal!
   "The factor determining interest that goes to reserves"
@@ -256,9 +256,9 @@ type MarketDailySnapshot implements MarketInfo @entity {
 
   # Fields that are not in compounds api
   "Block the market is updated to"
-  accrualBlockNumber: Int
+  accrualBlockNumber: BigInt
   "Timestamp the market was most recently updated"
-  blockTimestamp: Int!
+  blockTimestamp: BigInt!
   "The history of the markets borrow index return (Think S&P 500)"
   borrowIndex: BigDecimal!
   "The factor determining interest that goes to reserves"
@@ -411,9 +411,9 @@ interface CTokenTransfer {
   "Account that sent tokens"
   from: Bytes!
   "Block number"
-  blockNumber: Int!
+  blockNumber: BigInt!
   "Block time"
-  blockTime: Int!
+  blockTime: BigInt!
   "The cToken transferred"
   market: Market!
 }
@@ -434,9 +434,9 @@ type TransferEvent implements CTokenTransfer @entity(immutable: true) {
   "Account that sent tokens"
   from: Bytes!
   "Block number"
-  blockNumber: Int!
+  blockNumber: BigInt!
   "Block time"
-  blockTime: Int!
+  blockTime: BigInt!
   "The cToken transferred"
   market: Market!
 }
@@ -457,9 +457,9 @@ type MintEvent implements CTokenTransfer @entity(immutable: true) {
   "Account that sent tokens (CToken contract)"
   from: Bytes!
   "Block number"
-  blockNumber: Int!
+  blockNumber: BigInt!
   "Block time"
-  blockTime: Int!
+  blockTime: BigInt!
   "The cToken transferred"
   market: Market!
   "Underlying token amount transferred"
@@ -482,9 +482,9 @@ type RedeemEvent implements CTokenTransfer @entity(immutable: true) {
   "Account that sent tokens (redeemer)"
   from: Bytes!
   "Block number"
-  blockNumber: Int!
+  blockNumber: BigInt!
   "Block time"
-  blockTime: Int!
+  blockTime: BigInt!
   "The cToken transferred"
   market: Market!
   "Underlying token amount transferred"
@@ -507,9 +507,9 @@ type LiquidationEvent implements CTokenTransfer @entity(immutable: true) {
   "Account being liquidated (borrower)"
   from: Bytes!
   "Block number"
-  blockNumber: Int!
+  blockNumber: BigInt!
   "Block time"
-  blockTime: Int!
+  blockTime: BigInt!
   "cToken that was seized as collateral"
   market: Market!
   "The cToken that was repaid during this liquidation"
@@ -546,9 +546,9 @@ interface UnderlyingTransfer {
   "Account that borrowed the tokens"
   borrower: Bytes!
   "Block number"
-  blockNumber: Int!
+  blockNumber: BigInt!
   "Block time"
-  blockTime: Int!
+  blockTime: BigInt!
   "Symbol of the borrowed underlying asset"
   underlyingSymbol: String!
 }
@@ -570,9 +570,9 @@ type BorrowEvent implements UnderlyingTransfer @entity(immutable: true) {
   "Account that borrowed the tokens"
   borrower: Bytes!
   "Block number"
-  blockNumber: Int!
+  blockNumber: BigInt!
   "Block time"
-  blockTime: Int!
+  blockTime: BigInt!
   "Symbol of the borrowed underlying asset"
   underlyingSymbol: String!
 }
@@ -595,9 +595,9 @@ type RepayEvent implements UnderlyingTransfer @entity(immutable: true) {
   "Account that borrowed the tokens"
   borrower: Bytes!
   "Block number"
-  blockNumber: Int!
+  blockNumber: BigInt!
   "Block time"
-  blockTime: Int!
+  blockTime: BigInt!
   "Symbol of the borrowed underlying asset"
   underlyingSymbol: String!
   "Payer of the borrow funds"

--- a/schema.graphql
+++ b/schema.graphql
@@ -136,6 +136,9 @@ type Market implements MarketInfo @entity {
   "Underlying token decimal length"
   underlyingDecimals: Int!
 
+  "Accounts that have interacted with this market"
+  accounts: [AccountCToken!]! @derivedFrom(field: "market")
+
   # @yhayun - added specifically for benqi:
   "Underlying token"
   denomination: Token
@@ -145,7 +148,7 @@ type Market implements MarketInfo @entity {
   "All cTokenTransfer events which the token of this market is being transfered (i.e. LiquidationEvents only appear on the Collateral market)"
   cTokenTransfers: [CTokenTransfer!]! @derivedFrom(field: "market")
   "Transfers of the Underlying Token where no market token is being transfered (i.e. Borrow and Repay)"
-  underlyingTransfer: [UnderlyingTransfer!]! @derivedFrom(field: "market")
+  underlyingTransfers: [UnderlyingTransfer!]! @derivedFrom(field: "market")
 
   hourlySnapshots: [MarketHourlySnapshot!]! @derivedFrom(field: "market")
   dailySnapshots: [MarketDailySnapshot!]! @derivedFrom(field: "market")
@@ -162,7 +165,7 @@ type MarketHourlySnapshot implements MarketInfo @entity {
   "UTC timestamp for the beginning of the hour (ex.: timestamp for 01:00:00, 14:00:00, ...)"
   timestamp: BigInt!
   lastBlockNumber: BigInt!
-  lastBlockHash: String!
+  lastBlockHash: Bytes!
 
   ### INTERFACE FIELDS
   #Fields that match compounds API
@@ -225,7 +228,7 @@ type MarketDailySnapshot implements MarketInfo @entity {
   "UTC timestamp for the beginning of the day (ex.: timestamp for Day 1 00:00:00, Day 2 00:00:00, ...)"
   timestamp: BigInt!
   lastBlockNumber: BigInt!
-  lastBlockHash: String!
+  lastBlockHash: Bytes!
 
   ### INTERFACE FIELDS
   #Fields that match compounds API
@@ -277,13 +280,19 @@ type MarketDailySnapshot implements MarketInfo @entity {
   ### END OF INTERFACE FIELDS
 }
 
-type AccountSnapshot @entity(immutable: true) {
+type AccountMarketSnapshot @entity {
+  "AccountId-MarketId"
   id: ID!
-  account: Account!
-  market: Market!
-  blockNumber: Int!
-  supply_amount: BigDecimal!
-  borrow_amount: BigDecimal!
+  accountMarket: AccountCToken!
+  accrualBlockNumber: BigInt
+  blockNumber: BigInt!
+  timestamp: BigInt!
+  totalSupplyAmount: BigDecimal!
+  storedBorrowBalance: BigDecimal!
+  borrowBalanceWithInterest: BigDecimal!
+  marketBorrowIndex: BigDecimal!
+  accountBorrowIndex: BigDecimal!
+  exchangeRate: BigDecimal!
 }
 
 """
@@ -348,6 +357,9 @@ type AccountCToken @entity {
   totalUnderlyingRepaid: BigDecimal!
   "Current borrow balance stored in contract (exclusive of interest since accrualBlockNumber)"
   storedBorrowBalance: BigDecimal!
+
+  "Historical snapshots for this Account-Market association"
+  snapshots: [AccountMarketSnapshot!]! @derivedFrom(field: "accountMarket")
 
   # The following values are added by the JS Wrapper, and must be calculated with the most up
   # to date values based on the block delta for market.exchangeRate and market.borrowIndex

--- a/src/mappings/comptroller.ts
+++ b/src/mappings/comptroller.ts
@@ -9,7 +9,7 @@ import {
   NewPriceOracle,
   MarketListed,
 } from "../types/Comptroller/Comptroller";
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, ethereum } from "@graphprotocol/graph-ts";
 import { CToken } from "../types/templates";
 import { Market, Comptroller, Account } from "../types/schema";
 import { mantissaFactorBD, updateCommonCTokenStats, createAccount } from "./helpers";
@@ -107,6 +107,10 @@ export function handleNewPriceOracle(event: NewPriceOracle): void {
   }
   comptroller.priceOracle = event.params.newPriceOracle;
   comptroller.save();
+}
+
+export function handlehandleNewBlock(block: ethereum.Block): void {
+  // Define the granularity of blocks to skip to create a periodic snapshot
 }
 
 export function getOrCreateComptroller(): Comptroller {

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -151,11 +151,12 @@ export function handleBorrow(event: Borrow): void {
 
   let borrowAmountBD = event.params.borrowAmount.toBigDecimal().div(exponentToBigDecimal(market.underlyingDecimals));
 
-  cTokenStats.storedBorrowBalance = event.params.accountBorrows
+  let accountBorrows = event.params.accountBorrows
     .toBigDecimal()
     .div(exponentToBigDecimal(market.underlyingDecimals))
     .truncate(market.underlyingDecimals);
 
+  cTokenStats.storedBorrowBalance = accountBorrows;
   cTokenStats.accountBorrowIndex = market.borrowIndex;
   cTokenStats.totalUnderlyingBorrowed = cTokenStats.totalUnderlyingBorrowed.plus(borrowAmountBD);
   cTokenStats.save();
@@ -165,14 +166,7 @@ export function handleBorrow(event: Borrow): void {
     .concat("-")
     .concat(event.transactionLogIndex.toString());
 
-  let borrowAmount = event.params.borrowAmount
-    .toBigDecimal()
-    .div(exponentToBigDecimal(market.underlyingDecimals))
-    .truncate(market.underlyingDecimals);
-
-  let accountBorrows = event.params.accountBorrows
-    .toBigDecimal()
-    .div(exponentToBigDecimal(market.underlyingDecimals))
+  let borrowAmount = borrowAmountBD
     .truncate(market.underlyingDecimals);
 
   let borrow = new BorrowEvent(borrowID);
@@ -224,11 +218,12 @@ export function handleRepayBorrow(event: RepayBorrow): void {
 
   let repayAmountBD = event.params.repayAmount.toBigDecimal().div(exponentToBigDecimal(market.underlyingDecimals));
 
-  cTokenStats.storedBorrowBalance = event.params.accountBorrows
+  let accountBorrows = event.params.accountBorrows
     .toBigDecimal()
     .div(exponentToBigDecimal(market.underlyingDecimals))
     .truncate(market.underlyingDecimals);
 
+  cTokenStats.storedBorrowBalance = accountBorrows;
   cTokenStats.accountBorrowIndex = market.borrowIndex;
   cTokenStats.totalUnderlyingRepaid = cTokenStats.totalUnderlyingRepaid.plus(repayAmountBD);
   cTokenStats.save();
@@ -238,15 +233,7 @@ export function handleRepayBorrow(event: RepayBorrow): void {
     .concat("-")
     .concat(event.transactionLogIndex.toString());
 
-  let repayAmount = event.params.repayAmount
-    .toBigDecimal()
-    .div(exponentToBigDecimal(market.underlyingDecimals))
-    .truncate(market.underlyingDecimals);
-
-  let accountBorrows = event.params.accountBorrows
-    .toBigDecimal()
-    .div(exponentToBigDecimal(market.underlyingDecimals))
-    .truncate(market.underlyingDecimals);
+  let repayAmount = repayAmountBD.truncate(market.underlyingDecimals);
 
   let repay = new RepayEvent(repayID);
   repay.amount = repayAmount;

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -66,8 +66,8 @@ export function handleMint(event: Mint): void {
   mint.amount = cTokenAmount;
   mint.to = event.params.minter;
   mint.from = event.address;
-  mint.blockNumber = event.block.number.toI32();
-  mint.blockTime = event.block.timestamp.toI32();
+  mint.blockNumber = event.block.number;
+  mint.blockTime = event.block.timestamp;
   mint.market = market.id;
   mint.underlyingAmount = underlyingAmount;
   mint.save();
@@ -108,8 +108,8 @@ export function handleRedeem(event: Redeem): void {
   redeem.amount = cTokenAmount;
   redeem.to = event.address;
   redeem.from = event.params.redeemer;
-  redeem.blockNumber = event.block.number.toI32();
-  redeem.blockTime = event.block.timestamp.toI32();
+  redeem.blockNumber = event.block.number;
+  redeem.blockTime = event.block.timestamp;
   redeem.market = market.id;
   redeem.underlyingAmount = underlyingAmount;
   redeem.save();
@@ -179,8 +179,8 @@ export function handleBorrow(event: Borrow): void {
   borrow.amount = borrowAmount;
   borrow.accountBorrows = accountBorrows;
   borrow.borrower = event.params.borrower;
-  borrow.blockNumber = event.block.number.toI32();
-  borrow.blockTime = event.block.timestamp.toI32();
+  borrow.blockNumber = event.block.number;
+  borrow.blockTime = event.block.timestamp;
   borrow.underlyingSymbol = market.underlyingSymbol;
   borrow.save();
 }
@@ -252,8 +252,8 @@ export function handleRepayBorrow(event: RepayBorrow): void {
   repay.amount = repayAmount;
   repay.accountBorrows = accountBorrows;
   repay.borrower = event.params.borrower;
-  repay.blockNumber = event.block.number.toI32();
-  repay.blockTime = event.block.timestamp.toI32();
+  repay.blockNumber = event.block.number;
+  repay.blockTime = event.block.timestamp;
   repay.underlyingSymbol = market.underlyingSymbol;
   repay.payer = event.params.payer;
   repay.save();
@@ -323,8 +323,8 @@ export function handleLiquidateBorrow(event: LiquidateBorrow): void {
   liquidation.amount = cTokenAmount;
   liquidation.to = event.params.liquidator;
   liquidation.from = event.params.borrower;
-  liquidation.blockNumber = event.block.number.toI32();
-  liquidation.blockTime = event.block.timestamp.toI32();
+  liquidation.blockNumber = event.block.number;
+  liquidation.blockTime = event.block.timestamp;
   liquidation.underlyingSymbol = marketRepayToken.underlyingSymbol;
   liquidation.underlyingRepayAmount = underlyingRepayAmount;
   liquidation.market = marketCTokenLiquidated!.id;
@@ -355,8 +355,8 @@ export function handleTransfer(event: Transfer): void {
   if (market == null) {
     market = createMarket(marketID);
   }
-  if (market.accrualBlockNumber != event.block.number.toI32()) {
-    market = updateMarket(event.address, event.block.number.toI32(), event.block.timestamp.toI32());
+  if (market.accrualBlockNumber != event.block.number) {
+    market = updateMarket(event.address, event.block.number, event.block.timestamp);
   }
 
   let amountUnderlying = market.exchangeRate.times(event.params.amount.toBigDecimal().div(cTokenDecimalsBD));
@@ -437,14 +437,14 @@ export function handleTransfer(event: Transfer): void {
   transfer.amount = event.params.amount.toBigDecimal().div(cTokenDecimalsBD);
   transfer.to = event.params.to;
   transfer.from = event.params.from;
-  transfer.blockNumber = event.block.number.toI32();
-  transfer.blockTime = event.block.timestamp.toI32();
+  transfer.blockNumber = event.block.number;
+  transfer.blockTime = event.block.timestamp;
   transfer.market = market.id;
   transfer.save();
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
-  updateMarket(event.address, event.block.number.toI32(), event.block.timestamp.toI32());
+  updateMarket(event.address, event.block.number, event.block.timestamp);
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -18,6 +18,7 @@ export let cTokenDecimals = 8;
 export let mantissaFactorBD: BigDecimal = exponentToBigDecimal(18);
 export let cTokenDecimalsBD: BigDecimal = exponentToBigDecimal(8);
 export let zeroBD = BigDecimal.fromString("0");
+export let zeroBI = BigInt.fromI32(0);
 
 export function createAccountCToken(
   cTokenStatsID: string,

--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -12,6 +12,7 @@ import { CToken } from "../types/templates/CToken/CToken";
 
 import { exponentToBigDecimal, mantissaFactor, mantissaFactorBD, cTokenDecimalsBD, zeroBD } from "./helpers";
 import { MANTISSA_FACTOR, QIAVAX_TOKEN_ADDRESS, WAVAX_TOKEN_ADDRESS } from "./constants";
+import { getOrCreateComptroller } from './comptroller';
 
 let cUSDCAddress = "0x39aa39c021dfbae8fac545936693ac917d5e7563";
 let cETHAddress = "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5";
@@ -26,7 +27,7 @@ function getTokenPrice(
   // @ts-ignore
   underlyingDecimals: i32
 ): BigDecimal {
-  let comptroller = Comptroller.load("1");
+  let comptroller = getOrCreateComptroller();
   let oracleAddress = comptroller.priceOracle as Address;
   let underlyingPrice: BigDecimal;
   let priceOracle1Address = Address.fromString("02557a5e05defeffd4cae6d83ea3d173b272c904");
@@ -75,7 +76,7 @@ function getTokenPrice(
 // Returns the price of USDC in eth. i.e. 0.005 would mean ETH is $200
 // @ts-ignore
 function getUSDCpriceETH(blockNumber: i32): BigDecimal {
-  let comptroller = Comptroller.load("1");
+  let comptroller = getOrCreateComptroller();
   let oracleAddress = comptroller.priceOracle as Address;
   let priceOracle1Address = Address.fromString("02557a5e05defeffd4cae6d83ea3d173b272c904");
   let USDCAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 ";
@@ -167,10 +168,10 @@ function getOrCreateMarket(id: string, token: Token): Market {
     market.reserveFactor = zeroBD;
     market.denomination = token.id;
     market.underlyingAddress = token.address;
-    market.underlyingName = token.name;
+    market.underlyingName = token.name!;
     market.underlyingDecimals = token.decimals;
     market.underlyingPrice = zeroBD;
-    market.underlyingSymbol = token.symbol;
+    market.underlyingSymbol = token.symbol!;
     market.underlyingPriceUSD = zeroBD;
     market.borrowRate = zeroBD;
     market.collateralFactor = zeroBD;
@@ -264,7 +265,7 @@ export function createMarketDEPRECATED(marketAddress: string): Market {
 // Only to be used after block 10678764, since it's aimed to fix the change to USD based price oracle.
 // @ts-ignore
 function getETHinUSD(blockNumber: i32): BigDecimal {
-  let comptroller = Comptroller.load("1");
+  let comptroller = getOrCreateComptroller();
   let oracleAddress = comptroller.priceOracle as Address;
   let oracle = PriceOracle2.bind(oracleAddress);
   let tryPrice = oracle.try_getUnderlyingPrice(Address.fromString(cETHAddress));

--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -134,7 +134,7 @@ export function createMarket(marketAddress: string): Market {
     market.save();
     return market;
   }
-  //edge case @yhayun, no market - returning emopty one:
+  //edge case @yhayun, no market - returning empty one:
   log.error("*** YHAYUN *** : No market provided", [marketAddress]);
   let tempToken = getOrCreateToken(marketAddress);
   let market = getOrCreateMarket(marketAddress, tempToken);
@@ -176,8 +176,8 @@ function getOrCreateMarket(id: string, token: Token): Market {
     market.borrowRate = zeroBD;
     market.collateralFactor = zeroBD;
     market.cash = zeroBD;
-    market.accrualBlockNumber = 0;
-    market.blockTimestamp = 0;
+    market.accrualBlockNumber = zeroBI;
+    market.blockTimestamp = zeroBI;
     market.borrowIndex = zeroBD;
     market.name = "";
     market.symbol = "";
@@ -254,8 +254,8 @@ export function createMarketDEPRECATED(marketAddress: string): Market {
   market.totalBorrows = zeroBD;
   market.totalSupply = zeroBD;
 
-  market.accrualBlockNumber = 0;
-  market.blockTimestamp = 0;
+  market.accrualBlockNumber = zeroBI;
+  market.blockTimestamp = zeroBI;
   market.borrowIndex = zeroBD;
   market.reserveFactor = (reserveFactor.reverted ? BigInt.fromI32(0) : reserveFactor.value).toBigDecimal();
 
@@ -276,7 +276,7 @@ function getETHinUSD(blockNumber: i32): BigDecimal {
 }
 
 // @ts-ignore
-export function updateMarket(marketAddress: Address, blockNumber: i32, blockTimestamp: i32): Market {
+export function updateMarket(marketAddress: Address, blockNumber: BigInt, blockTimestamp: BigInt): Market {
   let marketID = marketAddress.toHexString();
   let market = Market.load(marketID);
   if (market == null) {
@@ -331,7 +331,7 @@ export function updateMarket(marketAddress: Address, blockNumber: i32, blockTime
     // }
 
     //TODO @yhayun
-    // market.accrualBlockNumber = contract.accrualBlockNumber().toI32()
+    // market.accrualBlockNumber = contract.accrualBlockNumber()
     market.blockTimestamp = blockTimestamp;
     market.totalSupply = contract
       .totalSupply()

--- a/src/mappings/snapshots.ts
+++ b/src/mappings/snapshots.ts
@@ -1,0 +1,174 @@
+/* eslint-disable prefer-const */ // to satisfy AS compiler
+
+import { BigInt, Bytes, log } from '@graphprotocol/graph-ts';
+import { AccountCToken, AccountMarketSnapshot, Market, MarketDailySnapshot, MarketHourlySnapshot } from '../types/schema';
+import { zeroBD } from './helpers';
+
+// @ts-ignore
+let SECONDS_PER_HOUR = BigInt.fromI32(3600 as i32);
+// @ts-ignore
+let SECONDS_PER_DAY = BigInt.fromI32(24 * 3600 as i32);
+
+export function saveMarketSnapshots(market: Market, timestamp: BigInt, blockNumber: BigInt, blockHash: Bytes): void {
+  let hourly: MarketHourlySnapshot | null;
+  let daily: MarketDailySnapshot | null;
+
+  let hourlyTimestamp = extractHourlyTimestamp(timestamp);
+  let dailyTimestamp = extractDailyTimestamp(timestamp);
+
+  // Since the snapshots share the same interface, they can't have the same id
+  // and the if we don't use suffixes the hourly snapshot for the first hour of the day
+  // would have the same id as the daily snapshot for the same day
+  // So given that we won't be querying based on the ids, we'll rather use the timestamp themselves, it's ok to use suffixes
+  let hourlyId = getMarketSnapshotId(market, hourlyTimestamp) + "-1h";
+  let dailyId = getMarketSnapshotId(market, dailyTimestamp) + "-1d";
+
+  hourly = MarketHourlySnapshot.load(hourlyId);
+
+  if (!hourly) {
+    hourly = new MarketHourlySnapshot(hourlyId);
+  }
+  
+  daily = MarketDailySnapshot.load(dailyId);
+  
+  if (!daily) {
+    daily = new MarketDailySnapshot(dailyId);
+  }
+  
+  fillMarketSnapshotValues(hourly, market, hourlyTimestamp, blockNumber, blockHash);
+  fillMarketSnapshotValues(daily, market, dailyTimestamp, blockNumber, blockHash);
+
+  hourly.save();
+  daily.save();
+}
+
+export function updateAccountMarketSnapshot(accountMarket: AccountCToken, market: Market, blockNumber: BigInt, blockTimestamp: BigInt): AccountMarketSnapshot {
+  let id = accountMarket.id.concat('-').concat(blockNumber.toString());
+
+  let snapshot = AccountMarketSnapshot.load(id);
+  let previousSupplyAmount = zeroBD;
+  let previousBorrowAmount = zeroBD;
+
+  if (!snapshot) {
+    snapshot = new AccountMarketSnapshot(id);
+    snapshot.accountMarket = accountMarket.id;
+  } else {
+    previousBorrowAmount = snapshot.borrowBalanceWithInterest;
+    previousSupplyAmount = snapshot.totalSupplyAmount;
+  }
+
+  snapshot.blockNumber = blockNumber;
+  snapshot.timestamp = blockTimestamp;
+  snapshot.totalSupplyAmount = accountMarket.cTokenBalance;
+  snapshot.accountBorrowIndex = accountMarket.accountBorrowIndex;
+  snapshot.exchangeRate = market.exchangeRate;
+  snapshot.accrualBlockNumber = market.accrualBlockNumber;
+  snapshot.storedBorrowBalance = accountMarket.storedBorrowBalance;
+  snapshot.marketBorrowIndex = market.borrowIndex;
+
+  if (accountMarket.accountBorrowIndex.gt(zeroBD)) {
+    snapshot.borrowBalanceWithInterest = accountMarket.storedBorrowBalance.times(market.borrowIndex).div(accountMarket.accountBorrowIndex);
+  } else if (accountMarket.storedBorrowBalance.equals(zeroBD)) {
+    snapshot.borrowBalanceWithInterest = zeroBD;
+  } else {
+    log.error('Inconsistent borrow state. BorrowBalance: {}. BorrowIndex: {}', [accountMarket.storedBorrowBalance.toString(), accountMarket.accountBorrowIndex.toString()]);
+  }
+
+  snapshot.save();
+
+  let borrowIncrement = 0;
+  let supplyIncrement = 0;
+
+  if (previousBorrowAmount.equals(zeroBD) && snapshot.borrowBalanceWithInterest.gt(zeroBD)) {
+    // If the borrow amount passed from 0 to something, it's a new borrow
+    borrowIncrement = 1;
+  } else if (previousBorrowAmount.gt(zeroBD) && snapshot.borrowBalanceWithInterest.equals(zeroBD)) {
+    // else if the borrow began 0, the loan was closed
+    borrowIncrement = -1;
+  }
+
+  if (previousSupplyAmount.equals(zeroBD) && snapshot.totalSupplyAmount.gt(zeroBD)) {
+    // If the borrow amount passed from 0 to something, it's a new borrow
+    supplyIncrement = 1;
+  } else if (previousSupplyAmount.gt(zeroBD) && snapshot.totalSupplyAmount.equals(zeroBD)) {
+    // else if the borrow began 0, the loan was closed
+    supplyIncrement = -1;
+  }
+
+  if (supplyIncrement != 0 || borrowIncrement != 0) {
+    let market = Market.load(accountMarket.market);
+    
+    if (market) {
+      market.borrowersCount += borrowIncrement;
+      market.suppliersCount += supplyIncrement;
+      
+      market.save();
+    }
+  }
+
+  // Explicit cast needed for AssemblyScript
+  return snapshot as AccountMarketSnapshot;
+}
+
+function fillMarketSnapshotValues<S extends MarketDailySnapshot>(snapshot: S, market: Market, normalizedTimestamp: BigInt, blockNumber: BigInt, blockHash: Bytes): void {
+
+  /*
+  This function uses generics with the type constraint because:
+    a) AssemblyScript does not support interfaces or union types yet
+    b) So the VSCode can hint on the autocomplete with no complaints
+
+  But this type constraint is not yet enforced on AssemblyScript yet, so any types could be sent to this method
+  */
+
+  let id = snapshot.id;
+  for (let i = 0; i < market.entries.length; i++) {
+    let entry = market.entries[i];
+    snapshot.set(entry.key, entry.value);
+  }
+  snapshot.id = id;
+  snapshot.lastBlockHash = blockHash;
+  snapshot.lastBlockNumber = blockNumber;
+  snapshot.timestamp = normalizedTimestamp;
+  snapshot.market = market.id;
+
+  // The code below manually copies the market fields into the snapshot. Only to be used if the "automatic" code above does not work
+  /*
+  snapshot.accrualBlockNumber = market.accrualBlockNumber;
+  snapshot.blockTimestamp = market.blockTimestamp;
+  snapshot.borrowIndex = market.borrowIndex;
+  snapshot.borrowRate = market.borrowRate;
+  snapshot.borrowersCount = market.borrowersCount;
+  snapshot.cash = market.cash;
+  snapshot.collateralFactor = market.collateralFactor;
+  snapshot.exchangeRate = market.exchangeRate;
+  snapshot.interestRateModelAddress = market.interestRateModelAddress;
+  snapshot.market = market.id;
+  snapshot.reserveFactor = market.reserveFactor;
+  snapshot.reserves = market.reserves;
+  snapshot.suppliersCount = market.suppliersCount;
+  snapshot.supplyRate = market.supplyRate;
+  snapshot.totalBorrows = market.totalBorrows;
+  snapshot.totalFeesGenerated = market.totalFeesGenerated;
+  snapshot.totalProtocolFeesGenerated = market.totalProtocolFeesGenerated;
+  snapshot.totalRewardsDistributed = market.totalRewardsDistributed;
+  snapshot.totalSupply = market.totalSupply;
+  snapshot.underlyingPrice = market.underlyingPrice;
+  snapshot.underlyingPriceUSD = market.underlyingPriceUSD;
+
+  snapshot.lastBlockHash = blockHash;
+  snapshot.lastBlockNumber = blockNumber;
+  snapshot.timestamp = normalizedTimestamp;
+  */
+}
+
+function extractHourlyTimestamp(timestamp: BigInt): BigInt {
+  return timestamp.div(SECONDS_PER_HOUR);
+}
+
+function extractDailyTimestamp(timestamp: BigInt): BigInt {
+  return timestamp.div(SECONDS_PER_DAY);
+}
+
+function getMarketSnapshotId(market: Market, timestamp: BigInt): string {
+  return market.id.concat(timestamp.toString());
+}

--- a/src/mappings/snapshots.ts
+++ b/src/mappings/snapshots.ts
@@ -170,7 +170,7 @@ function extractDailyTimestamp(timestamp: BigInt): BigInt {
 }
 
 function truncateTimestamp(timestamp: BigInt, seconds: BigInt): BigInt {
-  return timestamp.div(seconds).plus(BigInt.fromI32(1)).times(seconds);
+  return timestamp.div(seconds).times(seconds);
 }
 
 function getMarketSnapshotId(market: Market, timestamp: BigInt): string {

--- a/src/mappings/snapshots.ts
+++ b/src/mappings/snapshots.ts
@@ -162,11 +162,15 @@ function fillMarketSnapshotValues<S extends MarketDailySnapshot>(snapshot: S, ma
 }
 
 function extractHourlyTimestamp(timestamp: BigInt): BigInt {
-  return timestamp.div(SECONDS_PER_HOUR);
+  return truncateTimestamp(timestamp, SECONDS_PER_HOUR);
 }
 
 function extractDailyTimestamp(timestamp: BigInt): BigInt {
-  return timestamp.div(SECONDS_PER_DAY);
+  return truncateTimestamp(timestamp, SECONDS_PER_DAY);
+}
+
+function truncateTimestamp(timestamp: BigInt, seconds: BigInt): BigInt {
+  return timestamp.div(seconds).plus(BigInt.fromI32(1)).times(seconds);
 }
 
 function getMarketSnapshotId(market: Market, timestamp: BigInt): string {

--- a/src/mappings/snapshots.ts
+++ b/src/mappings/snapshots.ts
@@ -174,5 +174,5 @@ function truncateTimestamp(timestamp: BigInt, seconds: BigInt): BigInt {
 }
 
 function getMarketSnapshotId(market: Market, timestamp: BigInt): string {
-  return market.id.concat(timestamp.toString());
+  return market.id.concat('-').concat(timestamp.toString());
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -265,22 +265,30 @@ export class Market extends Entity {
     this.set("underlyingPrice", Value.fromBigDecimal(value));
   }
 
-  get accrualBlockNumber(): i32 {
+  get accrualBlockNumber(): BigInt | null {
     let value = this.get("accrualBlockNumber");
-    return value.toI32();
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
   }
 
-  set accrualBlockNumber(value: i32) {
-    this.set("accrualBlockNumber", Value.fromI32(value));
+  set accrualBlockNumber(value: BigInt | null) {
+    if (value === null) {
+      this.unset("accrualBlockNumber");
+    } else {
+      this.set("accrualBlockNumber", Value.fromBigInt(value as BigInt));
+    }
   }
 
-  get blockTimestamp(): i32 {
+  get blockTimestamp(): BigInt {
     let value = this.get("blockTimestamp");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockTimestamp(value: i32) {
-    this.set("blockTimestamp", Value.fromI32(value));
+  set blockTimestamp(value: BigInt) {
+    this.set("blockTimestamp", Value.fromBigInt(value));
   }
 
   get borrowIndex(): BigDecimal {
@@ -514,13 +522,13 @@ export class MarketHourlySnapshot extends Entity {
     this.set("lastBlockNumber", Value.fromBigInt(value));
   }
 
-  get lastBlockHash(): string {
+  get lastBlockHash(): Bytes {
     let value = this.get("lastBlockHash");
-    return value.toString();
+    return value.toBytes();
   }
 
-  set lastBlockHash(value: string) {
-    this.set("lastBlockHash", Value.fromString(value));
+  set lastBlockHash(value: Bytes) {
+    this.set("lastBlockHash", Value.fromBytes(value));
   }
 
   get borrowRate(): BigDecimal {
@@ -655,22 +663,30 @@ export class MarketHourlySnapshot extends Entity {
     this.set("underlyingPrice", Value.fromBigDecimal(value));
   }
 
-  get accrualBlockNumber(): i32 {
+  get accrualBlockNumber(): BigInt | null {
     let value = this.get("accrualBlockNumber");
-    return value.toI32();
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
   }
 
-  set accrualBlockNumber(value: i32) {
-    this.set("accrualBlockNumber", Value.fromI32(value));
+  set accrualBlockNumber(value: BigInt | null) {
+    if (value === null) {
+      this.unset("accrualBlockNumber");
+    } else {
+      this.set("accrualBlockNumber", Value.fromBigInt(value as BigInt));
+    }
   }
 
-  get blockTimestamp(): i32 {
+  get blockTimestamp(): BigInt {
     let value = this.get("blockTimestamp");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockTimestamp(value: i32) {
-    this.set("blockTimestamp", Value.fromI32(value));
+  set blockTimestamp(value: BigInt) {
+    this.set("blockTimestamp", Value.fromBigInt(value));
   }
 
   get borrowIndex(): BigDecimal {
@@ -728,278 +744,286 @@ export class MarketHourlySnapshot extends Entity {
   }
 }
 
-export class MarketDailySnapshot extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
+  export class MarketDailySnapshot extends Entity {
+    constructor(id: string) {
+      super();
+      this.set("id", Value.fromString(id));
+    }
 
-  save(): void {
-    let id = this.get("id");
-    assert(id !== null, "Cannot save MarketDailySnapshot entity without an ID");
-    assert(
-      id.kind == ValueKind.STRING,
-      "Cannot save MarketDailySnapshot entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.'
-    );
-    store.set("MarketDailySnapshot", id.toString(), this);
-  }
+    save(): void {
+      let id = this.get("id");
+      assert(id !== null, "Cannot save MarketDailySnapshot entity without an ID");
+      assert(
+        id.kind == ValueKind.STRING,
+        "Cannot save MarketDailySnapshot entity with non-string ID. " +
+          'Considering using .toHex() to convert the "id" to a string.'
+      );
+      store.set("MarketDailySnapshot", id.toString(), this);
+    }
 
-  static load(id: string): MarketDailySnapshot | null {
-    return store.get("MarketDailySnapshot", id) as MarketDailySnapshot | null;
-  }
+    static load(id: string): MarketDailySnapshot | null {
+      return store.get("MarketDailySnapshot", id) as MarketDailySnapshot | null;
+    }
 
-  get id(): string {
-    let value = this.get("id");
-    return value.toString();
-  }
+    get id(): string {
+      let value = this.get("id");
+      return value.toString();
+    }
 
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
+    set id(value: string) {
+      this.set("id", Value.fromString(value));
+    }
 
-  get market(): string {
-    let value = this.get("market");
-    return value.toString();
-  }
+    get market(): string {
+      let value = this.get("market");
+      return value.toString();
+    }
 
-  set market(value: string) {
-    this.set("market", Value.fromString(value));
-  }
+    set market(value: string) {
+      this.set("market", Value.fromString(value));
+    }
 
-  get timestamp(): BigInt {
-    let value = this.get("timestamp");
-    return value.toBigInt();
-  }
+    get timestamp(): BigInt {
+      let value = this.get("timestamp");
+      return value.toBigInt();
+    }
 
-  set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value));
-  }
+    set timestamp(value: BigInt) {
+      this.set("timestamp", Value.fromBigInt(value));
+    }
 
-  get lastBlockNumber(): BigInt {
-    let value = this.get("lastBlockNumber");
-    return value.toBigInt();
-  }
+    get lastBlockNumber(): BigInt {
+      let value = this.get("lastBlockNumber");
+      return value.toBigInt();
+    }
 
-  set lastBlockNumber(value: BigInt) {
-    this.set("lastBlockNumber", Value.fromBigInt(value));
-  }
+    set lastBlockNumber(value: BigInt) {
+      this.set("lastBlockNumber", Value.fromBigInt(value));
+    }
 
-  get lastBlockHash(): string {
-    let value = this.get("lastBlockHash");
-    return value.toString();
-  }
-
-  set lastBlockHash(value: string) {
-    this.set("lastBlockHash", Value.fromString(value));
-  }
-
-  get borrowRate(): BigDecimal {
-    let value = this.get("borrowRate");
-    return value.toBigDecimal();
-  }
-
-  set borrowRate(value: BigDecimal) {
-    this.set("borrowRate", Value.fromBigDecimal(value));
-  }
-
-  get cash(): BigDecimal {
-    let value = this.get("cash");
-    return value.toBigDecimal();
-  }
-
-  set cash(value: BigDecimal) {
-    this.set("cash", Value.fromBigDecimal(value));
-  }
-
-  get collateralFactor(): BigDecimal {
-    let value = this.get("collateralFactor");
-    return value.toBigDecimal();
-  }
-
-  set collateralFactor(value: BigDecimal) {
-    this.set("collateralFactor", Value.fromBigDecimal(value));
-  }
-
-  get exchangeRate(): BigDecimal {
-    let value = this.get("exchangeRate");
-    return value.toBigDecimal();
-  }
-
-  set exchangeRate(value: BigDecimal) {
-    this.set("exchangeRate", Value.fromBigDecimal(value));
-  }
-
-  get interestRateModelAddress(): Bytes | null {
-    let value = this.get("interestRateModelAddress");
-    if (value === null || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
+    get lastBlockHash(): Bytes {
+      let value = this.get("lastBlockHash");
       return value.toBytes();
     }
-  }
 
-  set interestRateModelAddress(value: Bytes | null) {
-    if (value === null) {
-      this.unset("interestRateModelAddress");
-    } else {
-      this.set("interestRateModelAddress", Value.fromBytes(value as Bytes));
+    set lastBlockHash(value: Bytes) {
+      this.set("lastBlockHash", Value.fromBytes(value));
     }
-  }
 
-  get reserves(): BigDecimal | null {
-    let value = this.get("reserves");
-    if (value === null || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
+    get borrowRate(): BigDecimal {
+      let value = this.get("borrowRate");
       return value.toBigDecimal();
     }
-  }
 
-  set reserves(value: BigDecimal | null) {
-    if (value === null) {
-      this.unset("reserves");
-    } else {
-      this.set("reserves", Value.fromBigDecimal(value as BigDecimal));
+    set borrowRate(value: BigDecimal) {
+      this.set("borrowRate", Value.fromBigDecimal(value));
     }
-  }
 
-  get supplyRate(): BigDecimal | null {
-    let value = this.get("supplyRate");
-    if (value === null || value.kind == ValueKind.NULL) {
-      return null;
-    } else {
+    get cash(): BigDecimal {
+      let value = this.get("cash");
       return value.toBigDecimal();
     }
-  }
 
-  set supplyRate(value: BigDecimal | null) {
-    if (value === null) {
-      this.unset("supplyRate");
-    } else {
-      this.set("supplyRate", Value.fromBigDecimal(value as BigDecimal));
+    set cash(value: BigDecimal) {
+      this.set("cash", Value.fromBigDecimal(value));
+    }
+
+    get collateralFactor(): BigDecimal {
+      let value = this.get("collateralFactor");
+      return value.toBigDecimal();
+    }
+
+    set collateralFactor(value: BigDecimal) {
+      this.set("collateralFactor", Value.fromBigDecimal(value));
+    }
+
+    get exchangeRate(): BigDecimal {
+      let value = this.get("exchangeRate");
+      return value.toBigDecimal();
+    }
+
+    set exchangeRate(value: BigDecimal) {
+      this.set("exchangeRate", Value.fromBigDecimal(value));
+    }
+
+    get interestRateModelAddress(): Bytes | null {
+      let value = this.get("interestRateModelAddress");
+      if (value === null || value.kind == ValueKind.NULL) {
+        return null;
+      } else {
+        return value.toBytes();
+      }
+    }
+
+    set interestRateModelAddress(value: Bytes | null) {
+      if (value === null) {
+        this.unset("interestRateModelAddress");
+      } else {
+        this.set("interestRateModelAddress", Value.fromBytes(value as Bytes));
+      }
+    }
+
+    get reserves(): BigDecimal | null {
+      let value = this.get("reserves");
+      if (value === null || value.kind == ValueKind.NULL) {
+        return null;
+      } else {
+        return value.toBigDecimal();
+      }
+    }
+
+    set reserves(value: BigDecimal | null) {
+      if (value === null) {
+        this.unset("reserves");
+      } else {
+        this.set("reserves", Value.fromBigDecimal(value as BigDecimal));
+      }
+    }
+
+    get supplyRate(): BigDecimal | null {
+      let value = this.get("supplyRate");
+      if (value === null || value.kind == ValueKind.NULL) {
+        return null;
+      } else {
+        return value.toBigDecimal();
+      }
+    }
+
+    set supplyRate(value: BigDecimal | null) {
+      if (value === null) {
+        this.unset("supplyRate");
+      } else {
+        this.set("supplyRate", Value.fromBigDecimal(value as BigDecimal));
+      }
+    }
+
+    get totalBorrows(): BigDecimal {
+      let value = this.get("totalBorrows");
+      return value.toBigDecimal();
+    }
+
+    set totalBorrows(value: BigDecimal) {
+      this.set("totalBorrows", Value.fromBigDecimal(value));
+    }
+
+    get totalSupply(): BigDecimal {
+      let value = this.get("totalSupply");
+      return value.toBigDecimal();
+    }
+
+    set totalSupply(value: BigDecimal) {
+      this.set("totalSupply", Value.fromBigDecimal(value));
+    }
+
+    get suppliersCount(): i32 {
+      let value = this.get("suppliersCount");
+      return value.toI32();
+    }
+
+    set suppliersCount(value: i32) {
+      this.set("suppliersCount", Value.fromI32(value));
+    }
+
+    get borrowersCount(): i32 {
+      let value = this.get("borrowersCount");
+      return value.toI32();
+    }
+
+    set borrowersCount(value: i32) {
+      this.set("borrowersCount", Value.fromI32(value));
+    }
+
+    get underlyingPrice(): BigDecimal {
+      let value = this.get("underlyingPrice");
+      return value.toBigDecimal();
+    }
+
+    set underlyingPrice(value: BigDecimal) {
+      this.set("underlyingPrice", Value.fromBigDecimal(value));
+    }
+
+    get accrualBlockNumber(): BigInt | null {
+      let value = this.get("accrualBlockNumber");
+      if (value === null || value.kind == ValueKind.NULL) {
+        return null;
+      } else {
+        return value.toBigInt();
+      }
+    }
+
+    set accrualBlockNumber(value: BigInt | null) {
+      if (value === null) {
+        this.unset("accrualBlockNumber");
+      } else {
+        this.set("accrualBlockNumber", Value.fromBigInt(value as BigInt));
+      }
+    }
+
+    get blockTimestamp(): BigInt {
+      let value = this.get("blockTimestamp");
+      return value.toBigInt();
+    }
+
+    set blockTimestamp(value: BigInt) {
+      this.set("blockTimestamp", Value.fromBigInt(value));
+    }
+
+    get borrowIndex(): BigDecimal {
+      let value = this.get("borrowIndex");
+      return value.toBigDecimal();
+    }
+
+    set borrowIndex(value: BigDecimal) {
+      this.set("borrowIndex", Value.fromBigDecimal(value));
+    }
+
+    get reserveFactor(): BigDecimal {
+      let value = this.get("reserveFactor");
+      return value.toBigDecimal();
+    }
+
+    set reserveFactor(value: BigDecimal) {
+      this.set("reserveFactor", Value.fromBigDecimal(value));
+    }
+
+    get underlyingPriceUSD(): BigDecimal {
+      let value = this.get("underlyingPriceUSD");
+      return value.toBigDecimal();
+    }
+
+    set underlyingPriceUSD(value: BigDecimal) {
+      this.set("underlyingPriceUSD", Value.fromBigDecimal(value));
+    }
+
+    get totalRewardsDistributed(): Array<BigDecimal> {
+      let value = this.get("totalRewardsDistributed");
+      return value.toBigDecimalArray();
+    }
+
+    set totalRewardsDistributed(value: Array<BigDecimal>) {
+      this.set("totalRewardsDistributed", Value.fromBigDecimalArray(value));
+    }
+
+    get totalFeesGenerated(): BigDecimal {
+      let value = this.get("totalFeesGenerated");
+      return value.toBigDecimal();
+    }
+
+    set totalFeesGenerated(value: BigDecimal) {
+      this.set("totalFeesGenerated", Value.fromBigDecimal(value));
+    }
+
+    get totalProtocolFeesGenerated(): BigDecimal {
+      let value = this.get("totalProtocolFeesGenerated");
+      return value.toBigDecimal();
+    }
+
+    set totalProtocolFeesGenerated(value: BigDecimal) {
+      this.set("totalProtocolFeesGenerated", Value.fromBigDecimal(value));
     }
   }
 
-  get totalBorrows(): BigDecimal {
-    let value = this.get("totalBorrows");
-    return value.toBigDecimal();
-  }
-
-  set totalBorrows(value: BigDecimal) {
-    this.set("totalBorrows", Value.fromBigDecimal(value));
-  }
-
-  get totalSupply(): BigDecimal {
-    let value = this.get("totalSupply");
-    return value.toBigDecimal();
-  }
-
-  set totalSupply(value: BigDecimal) {
-    this.set("totalSupply", Value.fromBigDecimal(value));
-  }
-
-  get suppliersCount(): i32 {
-    let value = this.get("suppliersCount");
-    return value.toI32();
-  }
-
-  set suppliersCount(value: i32) {
-    this.set("suppliersCount", Value.fromI32(value));
-  }
-
-  get borrowersCount(): i32 {
-    let value = this.get("borrowersCount");
-    return value.toI32();
-  }
-
-  set borrowersCount(value: i32) {
-    this.set("borrowersCount", Value.fromI32(value));
-  }
-
-  get underlyingPrice(): BigDecimal {
-    let value = this.get("underlyingPrice");
-    return value.toBigDecimal();
-  }
-
-  set underlyingPrice(value: BigDecimal) {
-    this.set("underlyingPrice", Value.fromBigDecimal(value));
-  }
-
-  get accrualBlockNumber(): i32 {
-    let value = this.get("accrualBlockNumber");
-    return value.toI32();
-  }
-
-  set accrualBlockNumber(value: i32) {
-    this.set("accrualBlockNumber", Value.fromI32(value));
-  }
-
-  get blockTimestamp(): i32 {
-    let value = this.get("blockTimestamp");
-    return value.toI32();
-  }
-
-  set blockTimestamp(value: i32) {
-    this.set("blockTimestamp", Value.fromI32(value));
-  }
-
-  get borrowIndex(): BigDecimal {
-    let value = this.get("borrowIndex");
-    return value.toBigDecimal();
-  }
-
-  set borrowIndex(value: BigDecimal) {
-    this.set("borrowIndex", Value.fromBigDecimal(value));
-  }
-
-  get reserveFactor(): BigDecimal {
-    let value = this.get("reserveFactor");
-    return value.toBigDecimal();
-  }
-
-  set reserveFactor(value: BigDecimal) {
-    this.set("reserveFactor", Value.fromBigDecimal(value));
-  }
-
-  get underlyingPriceUSD(): BigDecimal {
-    let value = this.get("underlyingPriceUSD");
-    return value.toBigDecimal();
-  }
-
-  set underlyingPriceUSD(value: BigDecimal) {
-    this.set("underlyingPriceUSD", Value.fromBigDecimal(value));
-  }
-
-  get totalRewardsDistributed(): Array<BigDecimal> {
-    let value = this.get("totalRewardsDistributed");
-    return value.toBigDecimalArray();
-  }
-
-  set totalRewardsDistributed(value: Array<BigDecimal>) {
-    this.set("totalRewardsDistributed", Value.fromBigDecimalArray(value));
-  }
-
-  get totalFeesGenerated(): BigDecimal {
-    let value = this.get("totalFeesGenerated");
-    return value.toBigDecimal();
-  }
-
-  set totalFeesGenerated(value: BigDecimal) {
-    this.set("totalFeesGenerated", Value.fromBigDecimal(value));
-  }
-
-  get totalProtocolFeesGenerated(): BigDecimal {
-    let value = this.get("totalProtocolFeesGenerated");
-    return value.toBigDecimal();
-  }
-
-  set totalProtocolFeesGenerated(value: BigDecimal) {
-    this.set("totalProtocolFeesGenerated", Value.fromBigDecimal(value));
-  }
-}
-
-export class AccountSnapshot extends Entity {
+export class AccountMarketSnapshot extends Entity {
   constructor(id: string) {
     super();
     this.set("id", Value.fromString(id));
@@ -1007,17 +1031,23 @@ export class AccountSnapshot extends Entity {
 
   save(): void {
     let id = this.get("id");
-    assert(id !== null, "Cannot save AccountSnapshot entity without an ID");
+    assert(
+      id !== null,
+      "Cannot save AccountMarketSnapshot entity without an ID"
+    );
     assert(
       id.kind == ValueKind.STRING,
-      "Cannot save AccountSnapshot entity with non-string ID. " +
+      "Cannot save AccountMarketSnapshot entity with non-string ID. " +
         'Considering using .toHex() to convert the "id" to a string.'
     );
-    store.set("AccountSnapshot", id.toString(), this);
+    store.set("AccountMarketSnapshot", id.toString(), this);
   }
 
-  static load(id: string): AccountSnapshot | null {
-    return store.get("AccountSnapshot", id) as AccountSnapshot | null;
+  static load(id: string): AccountMarketSnapshot | null {
+    return store.get(
+      "AccountMarketSnapshot",
+      id
+    ) as AccountMarketSnapshot | null;
   }
 
   get id(): string {
@@ -1029,31 +1059,22 @@ export class AccountSnapshot extends Entity {
     this.set("id", Value.fromString(value));
   }
 
-  get account(): string {
-    let value = this.get("account");
+  get accountMarket(): string {
+    let value = this.get("accountMarket");
     return value.toString();
   }
 
-  set account(value: string) {
-    this.set("account", Value.fromString(value));
+  set accountMarket(value: string) {
+    this.set("accountMarket", Value.fromString(value));
   }
 
-  get market(): string {
-    let value = this.get("market");
-    return value.toString();
-  }
-
-  set market(value: string) {
-    this.set("market", Value.fromString(value));
-  }
-
-  get blockNumber(): i32 {
+  get blockNumber(): BigInt {
     let value = this.get("blockNumber");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockNumber(value: i32) {
-    this.set("blockNumber", Value.fromI32(value));
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
   }
 
   get supply_amount(): BigDecimal {
@@ -1438,22 +1459,22 @@ export class TransferEvent extends Entity {
     this.set("from", Value.fromBytes(value));
   }
 
-  get blockNumber(): i32 {
+  get blockNumber(): BigInt {
     let value = this.get("blockNumber");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockNumber(value: i32) {
-    this.set("blockNumber", Value.fromI32(value));
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
   }
 
-  get blockTime(): i32 {
+  get blockTime(): BigInt {
     let value = this.get("blockTime");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockTime(value: i32) {
-    this.set("blockTime", Value.fromI32(value));
+  set blockTime(value: BigInt) {
+    this.set("blockTime", Value.fromBigInt(value));
   }
 
   get market(): string {
@@ -1532,22 +1553,22 @@ export class MintEvent extends Entity {
     this.set("from", Value.fromBytes(value));
   }
 
-  get blockNumber(): i32 {
+  get blockNumber(): BigInt {
     let value = this.get("blockNumber");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockNumber(value: i32) {
-    this.set("blockNumber", Value.fromI32(value));
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
   }
 
-  get blockTime(): i32 {
+  get blockTime(): BigInt {
     let value = this.get("blockTime");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockTime(value: i32) {
-    this.set("blockTime", Value.fromI32(value));
+  set blockTime(value: BigInt) {
+    this.set("blockTime", Value.fromBigInt(value));
   }
 
   get market(): string {
@@ -1643,22 +1664,22 @@ export class RedeemEvent extends Entity {
     this.set("from", Value.fromBytes(value));
   }
 
-  get blockNumber(): i32 {
+  get blockNumber(): BigInt {
     let value = this.get("blockNumber");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockNumber(value: i32) {
-    this.set("blockNumber", Value.fromI32(value));
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
   }
 
-  get blockTime(): i32 {
+  get blockTime(): BigInt {
     let value = this.get("blockTime");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockTime(value: i32) {
-    this.set("blockTime", Value.fromI32(value));
+  set blockTime(value: BigInt) {
+    this.set("blockTime", Value.fromBigInt(value));
   }
 
   get market(): string {
@@ -1754,22 +1775,22 @@ export class LiquidationEvent extends Entity {
     this.set("from", Value.fromBytes(value));
   }
 
-  get blockNumber(): i32 {
+  get blockNumber(): BigInt {
     let value = this.get("blockNumber");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockNumber(value: i32) {
-    this.set("blockNumber", Value.fromI32(value));
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
   }
 
-  get blockTime(): i32 {
+  get blockTime(): BigInt {
     let value = this.get("blockTime");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockTime(value: i32) {
-    this.set("blockTime", Value.fromI32(value));
+  set blockTime(value: BigInt) {
+    this.set("blockTime", Value.fromBigInt(value));
   }
 
   get market(): string {
@@ -1884,22 +1905,22 @@ export class BorrowEvent extends Entity {
     this.set("borrower", Value.fromBytes(value));
   }
 
-  get blockNumber(): i32 {
+  get blockNumber(): BigInt {
     let value = this.get("blockNumber");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockNumber(value: i32) {
-    this.set("blockNumber", Value.fromI32(value));
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
   }
 
-  get blockTime(): i32 {
+  get blockTime(): BigInt {
     let value = this.get("blockTime");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockTime(value: i32) {
-    this.set("blockTime", Value.fromI32(value));
+  set blockTime(value: BigInt) {
+    this.set("blockTime", Value.fromBigInt(value));
   }
 
   get underlyingSymbol(): string {
@@ -1987,22 +2008,22 @@ export class RepayEvent extends Entity {
     this.set("borrower", Value.fromBytes(value));
   }
 
-  get blockNumber(): i32 {
+  get blockNumber(): BigInt {
     let value = this.get("blockNumber");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockNumber(value: i32) {
-    this.set("blockNumber", Value.fromI32(value));
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
   }
 
-  get blockTime(): i32 {
+  get blockTime(): BigInt {
     let value = this.get("blockTime");
-    return value.toI32();
+    return value.toBigInt();
   }
 
-  set blockTime(value: i32) {
-    this.set("blockTime", Value.fromI32(value));
+  set blockTime(value: BigInt) {
+    this.set("blockTime", Value.fromBigInt(value));
   }
 
   get underlyingSymbol(): string {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -124,6 +124,15 @@ export class Market extends Entity {
     return store.get("Market", id) as Market | null;
   }
 
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
   get borrowRate(): BigDecimal {
     let value = this.get("borrowRate");
     return value.toBigDecimal();
@@ -177,15 +186,6 @@ export class Market extends Entity {
     }
   }
 
-  get name(): string {
-    let value = this.get("name");
-    return value.toString();
-  }
-
-  set name(value: string) {
-    this.set("name", Value.fromString(value));
-  }
-
   get reserves(): BigDecimal | null {
     let value = this.get("reserves");
     if (value === null || value.kind == ValueKind.NULL) {
@@ -220,24 +220,6 @@ export class Market extends Entity {
     }
   }
 
-  get symbol(): string {
-    let value = this.get("symbol");
-    return value.toString();
-  }
-
-  set symbol(value: string) {
-    this.set("symbol", Value.fromString(value));
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    return value.toString();
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
   get totalBorrows(): BigDecimal {
     let value = this.get("totalBorrows");
     return value.toBigDecimal();
@@ -256,22 +238,22 @@ export class Market extends Entity {
     this.set("totalSupply", Value.fromBigDecimal(value));
   }
 
-  get underlyingAddress(): Bytes {
-    let value = this.get("underlyingAddress");
-    return value.toBytes();
+  get suppliersCount(): i32 {
+    let value = this.get("suppliersCount");
+    return value.toI32();
   }
 
-  set underlyingAddress(value: Bytes) {
-    this.set("underlyingAddress", Value.fromBytes(value));
+  set suppliersCount(value: i32) {
+    this.set("suppliersCount", Value.fromI32(value));
   }
 
-  get underlyingName(): string {
-    let value = this.get("underlyingName");
-    return value.toString();
+  get borrowersCount(): i32 {
+    let value = this.get("borrowersCount");
+    return value.toI32();
   }
 
-  set underlyingName(value: string) {
-    this.set("underlyingName", Value.fromString(value));
+  set borrowersCount(value: i32) {
+    this.set("borrowersCount", Value.fromI32(value));
   }
 
   get underlyingPrice(): BigDecimal {
@@ -281,15 +263,6 @@ export class Market extends Entity {
 
   set underlyingPrice(value: BigDecimal) {
     this.set("underlyingPrice", Value.fromBigDecimal(value));
-  }
-
-  get underlyingSymbol(): string {
-    let value = this.get("underlyingSymbol");
-    return value.toString();
-  }
-
-  set underlyingSymbol(value: string) {
-    this.set("underlyingSymbol", Value.fromString(value));
   }
 
   get accrualBlockNumber(): i32 {
@@ -337,13 +310,13 @@ export class Market extends Entity {
     this.set("underlyingPriceUSD", Value.fromBigDecimal(value));
   }
 
-  get underlyingDecimals(): i32 {
-    let value = this.get("underlyingDecimals");
-    return value.toI32();
+  get totalRewardsDistributed(): Array<BigDecimal> {
+    let value = this.get("totalRewardsDistributed");
+    return value.toBigDecimalArray();
   }
 
-  set underlyingDecimals(value: i32) {
-    this.set("underlyingDecimals", Value.fromI32(value));
+  set totalRewardsDistributed(value: Array<BigDecimal>) {
+    this.set("totalRewardsDistributed", Value.fromBigDecimalArray(value));
   }
 
   get totalFeesGenerated(): BigDecimal {
@@ -364,6 +337,60 @@ export class Market extends Entity {
     this.set("totalProtocolFeesGenerated", Value.fromBigDecimal(value));
   }
 
+  get name(): string {
+    let value = this.get("name");
+    return value.toString();
+  }
+
+  set name(value: string) {
+    this.set("name", Value.fromString(value));
+  }
+
+  get symbol(): string {
+    let value = this.get("symbol");
+    return value.toString();
+  }
+
+  set symbol(value: string) {
+    this.set("symbol", Value.fromString(value));
+  }
+
+  get underlyingAddress(): Bytes {
+    let value = this.get("underlyingAddress");
+    return value.toBytes();
+  }
+
+  set underlyingAddress(value: Bytes) {
+    this.set("underlyingAddress", Value.fromBytes(value));
+  }
+
+  get underlyingName(): string {
+    let value = this.get("underlyingName");
+    return value.toString();
+  }
+
+  set underlyingName(value: string) {
+    this.set("underlyingName", Value.fromString(value));
+  }
+
+  get underlyingSymbol(): string {
+    let value = this.get("underlyingSymbol");
+    return value.toString();
+  }
+
+  set underlyingSymbol(value: string) {
+    this.set("underlyingSymbol", Value.fromString(value));
+  }
+
+  get underlyingDecimals(): i32 {
+    let value = this.get("underlyingDecimals");
+    return value.toI32();
+  }
+
+  set underlyingDecimals(value: i32) {
+    this.set("underlyingDecimals", Value.fromI32(value));
+  }
+
   get denomination(): string | null {
     let value = this.get("denomination");
     if (value === null || value.kind == ValueKind.NULL) {
@@ -379,6 +406,672 @@ export class Market extends Entity {
     } else {
       this.set("denomination", Value.fromString(value as string));
     }
+  }
+
+  get repaymentsThroughLiquidation(): Array<string> {
+    let value = this.get("repaymentsThroughLiquidation");
+    return value.toStringArray();
+  }
+
+  set repaymentsThroughLiquidation(value: Array<string>) {
+    this.set("repaymentsThroughLiquidation", Value.fromStringArray(value));
+  }
+
+  get cTokenTransfers(): Array<string> {
+    let value = this.get("cTokenTransfers");
+    return value.toStringArray();
+  }
+
+  set cTokenTransfers(value: Array<string>) {
+    this.set("cTokenTransfers", Value.fromStringArray(value));
+  }
+
+  get underlyingTransfer(): Array<string> {
+    let value = this.get("underlyingTransfer");
+    return value.toStringArray();
+  }
+
+  set underlyingTransfer(value: Array<string>) {
+    this.set("underlyingTransfer", Value.fromStringArray(value));
+  }
+
+  get hourlySnapshots(): Array<string> {
+    let value = this.get("hourlySnapshots");
+    return value.toStringArray();
+  }
+
+  set hourlySnapshots(value: Array<string>) {
+    this.set("hourlySnapshots", Value.fromStringArray(value));
+  }
+
+  get dailySnapshots(): Array<string> {
+    let value = this.get("dailySnapshots");
+    return value.toStringArray();
+  }
+
+  set dailySnapshots(value: Array<string>) {
+    this.set("dailySnapshots", Value.fromStringArray(value));
+  }
+}
+
+export class MarketHourlySnapshot extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(
+      id !== null,
+      "Cannot save MarketHourlySnapshot entity without an ID"
+    );
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save MarketHourlySnapshot entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("MarketHourlySnapshot", id.toString(), this);
+  }
+
+  static load(id: string): MarketHourlySnapshot | null {
+    return store.get("MarketHourlySnapshot", id) as MarketHourlySnapshot | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get market(): string {
+    let value = this.get("market");
+    return value.toString();
+  }
+
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    return value.toBigInt();
+  }
+
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
+
+  get lastBlockNumber(): BigInt {
+    let value = this.get("lastBlockNumber");
+    return value.toBigInt();
+  }
+
+  set lastBlockNumber(value: BigInt) {
+    this.set("lastBlockNumber", Value.fromBigInt(value));
+  }
+
+  get lastBlockHash(): string {
+    let value = this.get("lastBlockHash");
+    return value.toString();
+  }
+
+  set lastBlockHash(value: string) {
+    this.set("lastBlockHash", Value.fromString(value));
+  }
+
+  get borrowRate(): BigDecimal {
+    let value = this.get("borrowRate");
+    return value.toBigDecimal();
+  }
+
+  set borrowRate(value: BigDecimal) {
+    this.set("borrowRate", Value.fromBigDecimal(value));
+  }
+
+  get cash(): BigDecimal {
+    let value = this.get("cash");
+    return value.toBigDecimal();
+  }
+
+  set cash(value: BigDecimal) {
+    this.set("cash", Value.fromBigDecimal(value));
+  }
+
+  get collateralFactor(): BigDecimal {
+    let value = this.get("collateralFactor");
+    return value.toBigDecimal();
+  }
+
+  set collateralFactor(value: BigDecimal) {
+    this.set("collateralFactor", Value.fromBigDecimal(value));
+  }
+
+  get exchangeRate(): BigDecimal {
+    let value = this.get("exchangeRate");
+    return value.toBigDecimal();
+  }
+
+  set exchangeRate(value: BigDecimal) {
+    this.set("exchangeRate", Value.fromBigDecimal(value));
+  }
+
+  get interestRateModelAddress(): Bytes | null {
+    let value = this.get("interestRateModelAddress");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set interestRateModelAddress(value: Bytes | null) {
+    if (value === null) {
+      this.unset("interestRateModelAddress");
+    } else {
+      this.set("interestRateModelAddress", Value.fromBytes(value as Bytes));
+    }
+  }
+
+  get reserves(): BigDecimal | null {
+    let value = this.get("reserves");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
+  }
+
+  set reserves(value: BigDecimal | null) {
+    if (value === null) {
+      this.unset("reserves");
+    } else {
+      this.set("reserves", Value.fromBigDecimal(value as BigDecimal));
+    }
+  }
+
+  get supplyRate(): BigDecimal | null {
+    let value = this.get("supplyRate");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
+  }
+
+  set supplyRate(value: BigDecimal | null) {
+    if (value === null) {
+      this.unset("supplyRate");
+    } else {
+      this.set("supplyRate", Value.fromBigDecimal(value as BigDecimal));
+    }
+  }
+
+  get totalBorrows(): BigDecimal {
+    let value = this.get("totalBorrows");
+    return value.toBigDecimal();
+  }
+
+  set totalBorrows(value: BigDecimal) {
+    this.set("totalBorrows", Value.fromBigDecimal(value));
+  }
+
+  get totalSupply(): BigDecimal {
+    let value = this.get("totalSupply");
+    return value.toBigDecimal();
+  }
+
+  set totalSupply(value: BigDecimal) {
+    this.set("totalSupply", Value.fromBigDecimal(value));
+  }
+
+  get suppliersCount(): i32 {
+    let value = this.get("suppliersCount");
+    return value.toI32();
+  }
+
+  set suppliersCount(value: i32) {
+    this.set("suppliersCount", Value.fromI32(value));
+  }
+
+  get borrowersCount(): i32 {
+    let value = this.get("borrowersCount");
+    return value.toI32();
+  }
+
+  set borrowersCount(value: i32) {
+    this.set("borrowersCount", Value.fromI32(value));
+  }
+
+  get underlyingPrice(): BigDecimal {
+    let value = this.get("underlyingPrice");
+    return value.toBigDecimal();
+  }
+
+  set underlyingPrice(value: BigDecimal) {
+    this.set("underlyingPrice", Value.fromBigDecimal(value));
+  }
+
+  get accrualBlockNumber(): i32 {
+    let value = this.get("accrualBlockNumber");
+    return value.toI32();
+  }
+
+  set accrualBlockNumber(value: i32) {
+    this.set("accrualBlockNumber", Value.fromI32(value));
+  }
+
+  get blockTimestamp(): i32 {
+    let value = this.get("blockTimestamp");
+    return value.toI32();
+  }
+
+  set blockTimestamp(value: i32) {
+    this.set("blockTimestamp", Value.fromI32(value));
+  }
+
+  get borrowIndex(): BigDecimal {
+    let value = this.get("borrowIndex");
+    return value.toBigDecimal();
+  }
+
+  set borrowIndex(value: BigDecimal) {
+    this.set("borrowIndex", Value.fromBigDecimal(value));
+  }
+
+  get reserveFactor(): BigDecimal {
+    let value = this.get("reserveFactor");
+    return value.toBigDecimal();
+  }
+
+  set reserveFactor(value: BigDecimal) {
+    this.set("reserveFactor", Value.fromBigDecimal(value));
+  }
+
+  get underlyingPriceUSD(): BigDecimal {
+    let value = this.get("underlyingPriceUSD");
+    return value.toBigDecimal();
+  }
+
+  set underlyingPriceUSD(value: BigDecimal) {
+    this.set("underlyingPriceUSD", Value.fromBigDecimal(value));
+  }
+
+  get totalRewardsDistributed(): Array<BigDecimal> {
+    let value = this.get("totalRewardsDistributed");
+    return value.toBigDecimalArray();
+  }
+
+  set totalRewardsDistributed(value: Array<BigDecimal>) {
+    this.set("totalRewardsDistributed", Value.fromBigDecimalArray(value));
+  }
+
+  get totalFeesGenerated(): BigDecimal {
+    let value = this.get("totalFeesGenerated");
+    return value.toBigDecimal();
+  }
+
+  set totalFeesGenerated(value: BigDecimal) {
+    this.set("totalFeesGenerated", Value.fromBigDecimal(value));
+  }
+
+  get totalProtocolFeesGenerated(): BigDecimal {
+    let value = this.get("totalProtocolFeesGenerated");
+    return value.toBigDecimal();
+  }
+
+  set totalProtocolFeesGenerated(value: BigDecimal) {
+    this.set("totalProtocolFeesGenerated", Value.fromBigDecimal(value));
+  }
+}
+
+export class MarketDailySnapshot extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save MarketDailySnapshot entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save MarketDailySnapshot entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("MarketDailySnapshot", id.toString(), this);
+  }
+
+  static load(id: string): MarketDailySnapshot | null {
+    return store.get("MarketDailySnapshot", id) as MarketDailySnapshot | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get market(): string {
+    let value = this.get("market");
+    return value.toString();
+  }
+
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    return value.toBigInt();
+  }
+
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
+
+  get lastBlockNumber(): BigInt {
+    let value = this.get("lastBlockNumber");
+    return value.toBigInt();
+  }
+
+  set lastBlockNumber(value: BigInt) {
+    this.set("lastBlockNumber", Value.fromBigInt(value));
+  }
+
+  get lastBlockHash(): string {
+    let value = this.get("lastBlockHash");
+    return value.toString();
+  }
+
+  set lastBlockHash(value: string) {
+    this.set("lastBlockHash", Value.fromString(value));
+  }
+
+  get borrowRate(): BigDecimal {
+    let value = this.get("borrowRate");
+    return value.toBigDecimal();
+  }
+
+  set borrowRate(value: BigDecimal) {
+    this.set("borrowRate", Value.fromBigDecimal(value));
+  }
+
+  get cash(): BigDecimal {
+    let value = this.get("cash");
+    return value.toBigDecimal();
+  }
+
+  set cash(value: BigDecimal) {
+    this.set("cash", Value.fromBigDecimal(value));
+  }
+
+  get collateralFactor(): BigDecimal {
+    let value = this.get("collateralFactor");
+    return value.toBigDecimal();
+  }
+
+  set collateralFactor(value: BigDecimal) {
+    this.set("collateralFactor", Value.fromBigDecimal(value));
+  }
+
+  get exchangeRate(): BigDecimal {
+    let value = this.get("exchangeRate");
+    return value.toBigDecimal();
+  }
+
+  set exchangeRate(value: BigDecimal) {
+    this.set("exchangeRate", Value.fromBigDecimal(value));
+  }
+
+  get interestRateModelAddress(): Bytes | null {
+    let value = this.get("interestRateModelAddress");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set interestRateModelAddress(value: Bytes | null) {
+    if (value === null) {
+      this.unset("interestRateModelAddress");
+    } else {
+      this.set("interestRateModelAddress", Value.fromBytes(value as Bytes));
+    }
+  }
+
+  get reserves(): BigDecimal | null {
+    let value = this.get("reserves");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
+  }
+
+  set reserves(value: BigDecimal | null) {
+    if (value === null) {
+      this.unset("reserves");
+    } else {
+      this.set("reserves", Value.fromBigDecimal(value as BigDecimal));
+    }
+  }
+
+  get supplyRate(): BigDecimal | null {
+    let value = this.get("supplyRate");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
+  }
+
+  set supplyRate(value: BigDecimal | null) {
+    if (value === null) {
+      this.unset("supplyRate");
+    } else {
+      this.set("supplyRate", Value.fromBigDecimal(value as BigDecimal));
+    }
+  }
+
+  get totalBorrows(): BigDecimal {
+    let value = this.get("totalBorrows");
+    return value.toBigDecimal();
+  }
+
+  set totalBorrows(value: BigDecimal) {
+    this.set("totalBorrows", Value.fromBigDecimal(value));
+  }
+
+  get totalSupply(): BigDecimal {
+    let value = this.get("totalSupply");
+    return value.toBigDecimal();
+  }
+
+  set totalSupply(value: BigDecimal) {
+    this.set("totalSupply", Value.fromBigDecimal(value));
+  }
+
+  get suppliersCount(): i32 {
+    let value = this.get("suppliersCount");
+    return value.toI32();
+  }
+
+  set suppliersCount(value: i32) {
+    this.set("suppliersCount", Value.fromI32(value));
+  }
+
+  get borrowersCount(): i32 {
+    let value = this.get("borrowersCount");
+    return value.toI32();
+  }
+
+  set borrowersCount(value: i32) {
+    this.set("borrowersCount", Value.fromI32(value));
+  }
+
+  get underlyingPrice(): BigDecimal {
+    let value = this.get("underlyingPrice");
+    return value.toBigDecimal();
+  }
+
+  set underlyingPrice(value: BigDecimal) {
+    this.set("underlyingPrice", Value.fromBigDecimal(value));
+  }
+
+  get accrualBlockNumber(): i32 {
+    let value = this.get("accrualBlockNumber");
+    return value.toI32();
+  }
+
+  set accrualBlockNumber(value: i32) {
+    this.set("accrualBlockNumber", Value.fromI32(value));
+  }
+
+  get blockTimestamp(): i32 {
+    let value = this.get("blockTimestamp");
+    return value.toI32();
+  }
+
+  set blockTimestamp(value: i32) {
+    this.set("blockTimestamp", Value.fromI32(value));
+  }
+
+  get borrowIndex(): BigDecimal {
+    let value = this.get("borrowIndex");
+    return value.toBigDecimal();
+  }
+
+  set borrowIndex(value: BigDecimal) {
+    this.set("borrowIndex", Value.fromBigDecimal(value));
+  }
+
+  get reserveFactor(): BigDecimal {
+    let value = this.get("reserveFactor");
+    return value.toBigDecimal();
+  }
+
+  set reserveFactor(value: BigDecimal) {
+    this.set("reserveFactor", Value.fromBigDecimal(value));
+  }
+
+  get underlyingPriceUSD(): BigDecimal {
+    let value = this.get("underlyingPriceUSD");
+    return value.toBigDecimal();
+  }
+
+  set underlyingPriceUSD(value: BigDecimal) {
+    this.set("underlyingPriceUSD", Value.fromBigDecimal(value));
+  }
+
+  get totalRewardsDistributed(): Array<BigDecimal> {
+    let value = this.get("totalRewardsDistributed");
+    return value.toBigDecimalArray();
+  }
+
+  set totalRewardsDistributed(value: Array<BigDecimal>) {
+    this.set("totalRewardsDistributed", Value.fromBigDecimalArray(value));
+  }
+
+  get totalFeesGenerated(): BigDecimal {
+    let value = this.get("totalFeesGenerated");
+    return value.toBigDecimal();
+  }
+
+  set totalFeesGenerated(value: BigDecimal) {
+    this.set("totalFeesGenerated", Value.fromBigDecimal(value));
+  }
+
+  get totalProtocolFeesGenerated(): BigDecimal {
+    let value = this.get("totalProtocolFeesGenerated");
+    return value.toBigDecimal();
+  }
+
+  set totalProtocolFeesGenerated(value: BigDecimal) {
+    this.set("totalProtocolFeesGenerated", Value.fromBigDecimal(value));
+  }
+}
+
+export class AccountSnapshot extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save AccountSnapshot entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save AccountSnapshot entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("AccountSnapshot", id.toString(), this);
+  }
+
+  static load(id: string): AccountSnapshot | null {
+    return store.get("AccountSnapshot", id) as AccountSnapshot | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get account(): string {
+    let value = this.get("account");
+    return value.toString();
+  }
+
+  set account(value: string) {
+    this.set("account", Value.fromString(value));
+  }
+
+  get market(): string {
+    let value = this.get("market");
+    return value.toString();
+  }
+
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
+  }
+
+  get blockNumber(): i32 {
+    let value = this.get("blockNumber");
+    return value.toI32();
+  }
+
+  set blockNumber(value: i32) {
+    this.set("blockNumber", Value.fromI32(value));
+  }
+
+  get supply_amount(): BigDecimal {
+    let value = this.get("supply_amount");
+    return value.toBigDecimal();
+  }
+
+  set supply_amount(value: BigDecimal) {
+    this.set("supply_amount", Value.fromBigDecimal(value));
+  }
+
+  get borrow_amount(): BigDecimal {
+    let value = this.get("borrow_amount");
+    return value.toBigDecimal();
+  }
+
+  set borrow_amount(value: BigDecimal) {
+    this.set("borrow_amount", Value.fromBigDecimal(value));
   }
 }
 
@@ -709,6 +1402,15 @@ export class TransferEvent extends Entity {
     this.set("id", Value.fromString(value));
   }
 
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
+  }
+
   get amount(): BigDecimal {
     let value = this.get("amount");
     return value.toBigDecimal();
@@ -754,13 +1456,13 @@ export class TransferEvent extends Entity {
     this.set("blockTime", Value.fromI32(value));
   }
 
-  get cTokenSymbol(): string {
-    let value = this.get("cTokenSymbol");
+  get market(): string {
+    let value = this.get("market");
     return value.toString();
   }
 
-  set cTokenSymbol(value: string) {
-    this.set("cTokenSymbol", Value.fromString(value));
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
   }
 }
 
@@ -794,6 +1496,15 @@ export class MintEvent extends Entity {
     this.set("id", Value.fromString(value));
   }
 
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
+  }
+
   get amount(): BigDecimal {
     let value = this.get("amount");
     return value.toBigDecimal();
@@ -839,13 +1550,13 @@ export class MintEvent extends Entity {
     this.set("blockTime", Value.fromI32(value));
   }
 
-  get cTokenSymbol(): string {
-    let value = this.get("cTokenSymbol");
+  get market(): string {
+    let value = this.get("market");
     return value.toString();
   }
 
-  set cTokenSymbol(value: string) {
-    this.set("cTokenSymbol", Value.fromString(value));
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
   }
 
   get underlyingAmount(): BigDecimal | null {
@@ -896,6 +1607,15 @@ export class RedeemEvent extends Entity {
     this.set("id", Value.fromString(value));
   }
 
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
+  }
+
   get amount(): BigDecimal {
     let value = this.get("amount");
     return value.toBigDecimal();
@@ -941,13 +1661,13 @@ export class RedeemEvent extends Entity {
     this.set("blockTime", Value.fromI32(value));
   }
 
-  get cTokenSymbol(): string {
-    let value = this.get("cTokenSymbol");
+  get market(): string {
+    let value = this.get("market");
     return value.toString();
   }
 
-  set cTokenSymbol(value: string) {
-    this.set("cTokenSymbol", Value.fromString(value));
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
   }
 
   get underlyingAmount(): BigDecimal | null {
@@ -998,6 +1718,15 @@ export class LiquidationEvent extends Entity {
     this.set("id", Value.fromString(value));
   }
 
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
+  }
+
   get amount(): BigDecimal {
     let value = this.get("amount");
     return value.toBigDecimal();
@@ -1043,13 +1772,22 @@ export class LiquidationEvent extends Entity {
     this.set("blockTime", Value.fromI32(value));
   }
 
-  get cTokenSymbol(): string {
-    let value = this.get("cTokenSymbol");
+  get market(): string {
+    let value = this.get("market");
     return value.toString();
   }
 
-  set cTokenSymbol(value: string) {
-    this.set("cTokenSymbol", Value.fromString(value));
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
+  }
+
+  get repayMarket(): string {
+    let value = this.get("repayMarket");
+    return value.toString();
+  }
+
+  set repayMarket(value: string) {
+    this.set("repayMarket", Value.fromString(value));
   }
 
   get underlyingSymbol(): string {
@@ -1099,6 +1837,24 @@ export class BorrowEvent extends Entity {
 
   set id(value: string) {
     this.set("id", Value.fromString(value));
+  }
+
+  get market(): string {
+    let value = this.get("market");
+    return value.toString();
+  }
+
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
+  }
+
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
   }
 
   get amount(): BigDecimal {
@@ -1184,6 +1940,24 @@ export class RepayEvent extends Entity {
 
   set id(value: string) {
     this.set("id", Value.fromString(value));
+  }
+
+  get market(): string {
+    let value = this.get("market");
+    return value.toString();
+  }
+
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
+  }
+
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
   }
 
   get amount(): BigDecimal {
@@ -1289,22 +2063,38 @@ export class Token extends Entity {
     this.set("address", Value.fromBytes(value));
   }
 
-  get name(): string {
+  get name(): string | null {
     let value = this.get("name");
-    return value.toString();
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toString();
+    }
   }
 
-  set name(value: string) {
-    this.set("name", Value.fromString(value));
+  set name(value: string | null) {
+    if (value === null) {
+      this.unset("name");
+    } else {
+      this.set("name", Value.fromString(value as string));
+    }
   }
 
-  get symbol(): string {
+  get symbol(): string | null {
     let value = this.get("symbol");
-    return value.toString();
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toString();
+    }
   }
 
-  set symbol(value: string) {
-    this.set("symbol", Value.fromString(value));
+  set symbol(value: string | null) {
+    if (value === null) {
+      this.unset("symbol");
+    } else {
+      this.set("symbol", Value.fromString(value as string));
+    }
   }
 
   get decimals(): i32 {
@@ -1316,12 +2106,20 @@ export class Token extends Entity {
     this.set("decimals", Value.fromI32(value));
   }
 
-  get totalSupply(): BigInt {
+  get totalSupply(): BigInt | null {
     let value = this.get("totalSupply");
-    return value.toBigInt();
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
   }
 
-  set totalSupply(value: BigInt) {
-    this.set("totalSupply", Value.fromBigInt(value));
+  set totalSupply(value: BigInt | null) {
+    if (value === null) {
+      this.unset("totalSupply");
+    } else {
+      this.set("totalSupply", Value.fromBigInt(value as BigInt));
+    }
   }
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -399,6 +399,15 @@ export class Market extends Entity {
     this.set("underlyingDecimals", Value.fromI32(value));
   }
 
+  get accounts(): Array<string> {
+    let value = this.get("accounts");
+    return value.toStringArray();
+  }
+
+  set accounts(value: Array<string>) {
+    this.set("accounts", Value.fromStringArray(value));
+  }
+
   get denomination(): string | null {
     let value = this.get("denomination");
     if (value === null || value.kind == ValueKind.NULL) {
@@ -434,13 +443,13 @@ export class Market extends Entity {
     this.set("cTokenTransfers", Value.fromStringArray(value));
   }
 
-  get underlyingTransfer(): Array<string> {
-    let value = this.get("underlyingTransfer");
+  get underlyingTransfers(): Array<string> {
+    let value = this.get("underlyingTransfers");
     return value.toStringArray();
   }
 
-  set underlyingTransfer(value: Array<string>) {
-    this.set("underlyingTransfer", Value.fromStringArray(value));
+  set underlyingTransfers(value: Array<string>) {
+    this.set("underlyingTransfers", Value.fromStringArray(value));
   }
 
   get hourlySnapshots(): Array<string> {
@@ -744,284 +753,284 @@ export class MarketHourlySnapshot extends Entity {
   }
 }
 
-  export class MarketDailySnapshot extends Entity {
-    constructor(id: string) {
-      super();
-      this.set("id", Value.fromString(id));
-    }
+export class MarketDailySnapshot extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
 
-    save(): void {
-      let id = this.get("id");
-      assert(id !== null, "Cannot save MarketDailySnapshot entity without an ID");
-      assert(
-        id.kind == ValueKind.STRING,
-        "Cannot save MarketDailySnapshot entity with non-string ID. " +
-          'Considering using .toHex() to convert the "id" to a string.'
-      );
-      store.set("MarketDailySnapshot", id.toString(), this);
-    }
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save MarketDailySnapshot entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save MarketDailySnapshot entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("MarketDailySnapshot", id.toString(), this);
+  }
 
-    static load(id: string): MarketDailySnapshot | null {
-      return store.get("MarketDailySnapshot", id) as MarketDailySnapshot | null;
-    }
+  static load(id: string): MarketDailySnapshot | null {
+    return store.get("MarketDailySnapshot", id) as MarketDailySnapshot | null;
+  }
 
-    get id(): string {
-      let value = this.get("id");
-      return value.toString();
-    }
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
 
-    set id(value: string) {
-      this.set("id", Value.fromString(value));
-    }
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
 
-    get market(): string {
-      let value = this.get("market");
-      return value.toString();
-    }
+  get market(): string {
+    let value = this.get("market");
+    return value.toString();
+  }
 
-    set market(value: string) {
-      this.set("market", Value.fromString(value));
-    }
+  set market(value: string) {
+    this.set("market", Value.fromString(value));
+  }
 
-    get timestamp(): BigInt {
-      let value = this.get("timestamp");
-      return value.toBigInt();
-    }
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    return value.toBigInt();
+  }
 
-    set timestamp(value: BigInt) {
-      this.set("timestamp", Value.fromBigInt(value));
-    }
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
 
-    get lastBlockNumber(): BigInt {
-      let value = this.get("lastBlockNumber");
-      return value.toBigInt();
-    }
+  get lastBlockNumber(): BigInt {
+    let value = this.get("lastBlockNumber");
+    return value.toBigInt();
+  }
 
-    set lastBlockNumber(value: BigInt) {
-      this.set("lastBlockNumber", Value.fromBigInt(value));
-    }
+  set lastBlockNumber(value: BigInt) {
+    this.set("lastBlockNumber", Value.fromBigInt(value));
+  }
 
-    get lastBlockHash(): Bytes {
-      let value = this.get("lastBlockHash");
+  get lastBlockHash(): Bytes {
+    let value = this.get("lastBlockHash");
+    return value.toBytes();
+  }
+
+  set lastBlockHash(value: Bytes) {
+    this.set("lastBlockHash", Value.fromBytes(value));
+  }
+
+  get borrowRate(): BigDecimal {
+    let value = this.get("borrowRate");
+    return value.toBigDecimal();
+  }
+
+  set borrowRate(value: BigDecimal) {
+    this.set("borrowRate", Value.fromBigDecimal(value));
+  }
+
+  get cash(): BigDecimal {
+    let value = this.get("cash");
+    return value.toBigDecimal();
+  }
+
+  set cash(value: BigDecimal) {
+    this.set("cash", Value.fromBigDecimal(value));
+  }
+
+  get collateralFactor(): BigDecimal {
+    let value = this.get("collateralFactor");
+    return value.toBigDecimal();
+  }
+
+  set collateralFactor(value: BigDecimal) {
+    this.set("collateralFactor", Value.fromBigDecimal(value));
+  }
+
+  get exchangeRate(): BigDecimal {
+    let value = this.get("exchangeRate");
+    return value.toBigDecimal();
+  }
+
+  set exchangeRate(value: BigDecimal) {
+    this.set("exchangeRate", Value.fromBigDecimal(value));
+  }
+
+  get interestRateModelAddress(): Bytes | null {
+    let value = this.get("interestRateModelAddress");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
       return value.toBytes();
     }
+  }
 
-    set lastBlockHash(value: Bytes) {
-      this.set("lastBlockHash", Value.fromBytes(value));
-    }
-
-    get borrowRate(): BigDecimal {
-      let value = this.get("borrowRate");
-      return value.toBigDecimal();
-    }
-
-    set borrowRate(value: BigDecimal) {
-      this.set("borrowRate", Value.fromBigDecimal(value));
-    }
-
-    get cash(): BigDecimal {
-      let value = this.get("cash");
-      return value.toBigDecimal();
-    }
-
-    set cash(value: BigDecimal) {
-      this.set("cash", Value.fromBigDecimal(value));
-    }
-
-    get collateralFactor(): BigDecimal {
-      let value = this.get("collateralFactor");
-      return value.toBigDecimal();
-    }
-
-    set collateralFactor(value: BigDecimal) {
-      this.set("collateralFactor", Value.fromBigDecimal(value));
-    }
-
-    get exchangeRate(): BigDecimal {
-      let value = this.get("exchangeRate");
-      return value.toBigDecimal();
-    }
-
-    set exchangeRate(value: BigDecimal) {
-      this.set("exchangeRate", Value.fromBigDecimal(value));
-    }
-
-    get interestRateModelAddress(): Bytes | null {
-      let value = this.get("interestRateModelAddress");
-      if (value === null || value.kind == ValueKind.NULL) {
-        return null;
-      } else {
-        return value.toBytes();
-      }
-    }
-
-    set interestRateModelAddress(value: Bytes | null) {
-      if (value === null) {
-        this.unset("interestRateModelAddress");
-      } else {
-        this.set("interestRateModelAddress", Value.fromBytes(value as Bytes));
-      }
-    }
-
-    get reserves(): BigDecimal | null {
-      let value = this.get("reserves");
-      if (value === null || value.kind == ValueKind.NULL) {
-        return null;
-      } else {
-        return value.toBigDecimal();
-      }
-    }
-
-    set reserves(value: BigDecimal | null) {
-      if (value === null) {
-        this.unset("reserves");
-      } else {
-        this.set("reserves", Value.fromBigDecimal(value as BigDecimal));
-      }
-    }
-
-    get supplyRate(): BigDecimal | null {
-      let value = this.get("supplyRate");
-      if (value === null || value.kind == ValueKind.NULL) {
-        return null;
-      } else {
-        return value.toBigDecimal();
-      }
-    }
-
-    set supplyRate(value: BigDecimal | null) {
-      if (value === null) {
-        this.unset("supplyRate");
-      } else {
-        this.set("supplyRate", Value.fromBigDecimal(value as BigDecimal));
-      }
-    }
-
-    get totalBorrows(): BigDecimal {
-      let value = this.get("totalBorrows");
-      return value.toBigDecimal();
-    }
-
-    set totalBorrows(value: BigDecimal) {
-      this.set("totalBorrows", Value.fromBigDecimal(value));
-    }
-
-    get totalSupply(): BigDecimal {
-      let value = this.get("totalSupply");
-      return value.toBigDecimal();
-    }
-
-    set totalSupply(value: BigDecimal) {
-      this.set("totalSupply", Value.fromBigDecimal(value));
-    }
-
-    get suppliersCount(): i32 {
-      let value = this.get("suppliersCount");
-      return value.toI32();
-    }
-
-    set suppliersCount(value: i32) {
-      this.set("suppliersCount", Value.fromI32(value));
-    }
-
-    get borrowersCount(): i32 {
-      let value = this.get("borrowersCount");
-      return value.toI32();
-    }
-
-    set borrowersCount(value: i32) {
-      this.set("borrowersCount", Value.fromI32(value));
-    }
-
-    get underlyingPrice(): BigDecimal {
-      let value = this.get("underlyingPrice");
-      return value.toBigDecimal();
-    }
-
-    set underlyingPrice(value: BigDecimal) {
-      this.set("underlyingPrice", Value.fromBigDecimal(value));
-    }
-
-    get accrualBlockNumber(): BigInt | null {
-      let value = this.get("accrualBlockNumber");
-      if (value === null || value.kind == ValueKind.NULL) {
-        return null;
-      } else {
-        return value.toBigInt();
-      }
-    }
-
-    set accrualBlockNumber(value: BigInt | null) {
-      if (value === null) {
-        this.unset("accrualBlockNumber");
-      } else {
-        this.set("accrualBlockNumber", Value.fromBigInt(value as BigInt));
-      }
-    }
-
-    get blockTimestamp(): BigInt {
-      let value = this.get("blockTimestamp");
-      return value.toBigInt();
-    }
-
-    set blockTimestamp(value: BigInt) {
-      this.set("blockTimestamp", Value.fromBigInt(value));
-    }
-
-    get borrowIndex(): BigDecimal {
-      let value = this.get("borrowIndex");
-      return value.toBigDecimal();
-    }
-
-    set borrowIndex(value: BigDecimal) {
-      this.set("borrowIndex", Value.fromBigDecimal(value));
-    }
-
-    get reserveFactor(): BigDecimal {
-      let value = this.get("reserveFactor");
-      return value.toBigDecimal();
-    }
-
-    set reserveFactor(value: BigDecimal) {
-      this.set("reserveFactor", Value.fromBigDecimal(value));
-    }
-
-    get underlyingPriceUSD(): BigDecimal {
-      let value = this.get("underlyingPriceUSD");
-      return value.toBigDecimal();
-    }
-
-    set underlyingPriceUSD(value: BigDecimal) {
-      this.set("underlyingPriceUSD", Value.fromBigDecimal(value));
-    }
-
-    get totalRewardsDistributed(): Array<BigDecimal> {
-      let value = this.get("totalRewardsDistributed");
-      return value.toBigDecimalArray();
-    }
-
-    set totalRewardsDistributed(value: Array<BigDecimal>) {
-      this.set("totalRewardsDistributed", Value.fromBigDecimalArray(value));
-    }
-
-    get totalFeesGenerated(): BigDecimal {
-      let value = this.get("totalFeesGenerated");
-      return value.toBigDecimal();
-    }
-
-    set totalFeesGenerated(value: BigDecimal) {
-      this.set("totalFeesGenerated", Value.fromBigDecimal(value));
-    }
-
-    get totalProtocolFeesGenerated(): BigDecimal {
-      let value = this.get("totalProtocolFeesGenerated");
-      return value.toBigDecimal();
-    }
-
-    set totalProtocolFeesGenerated(value: BigDecimal) {
-      this.set("totalProtocolFeesGenerated", Value.fromBigDecimal(value));
+  set interestRateModelAddress(value: Bytes | null) {
+    if (value === null) {
+      this.unset("interestRateModelAddress");
+    } else {
+      this.set("interestRateModelAddress", Value.fromBytes(value as Bytes));
     }
   }
+
+  get reserves(): BigDecimal | null {
+    let value = this.get("reserves");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
+  }
+
+  set reserves(value: BigDecimal | null) {
+    if (value === null) {
+      this.unset("reserves");
+    } else {
+      this.set("reserves", Value.fromBigDecimal(value as BigDecimal));
+    }
+  }
+
+  get supplyRate(): BigDecimal | null {
+    let value = this.get("supplyRate");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
+  }
+
+  set supplyRate(value: BigDecimal | null) {
+    if (value === null) {
+      this.unset("supplyRate");
+    } else {
+      this.set("supplyRate", Value.fromBigDecimal(value as BigDecimal));
+    }
+  }
+
+  get totalBorrows(): BigDecimal {
+    let value = this.get("totalBorrows");
+    return value.toBigDecimal();
+  }
+
+  set totalBorrows(value: BigDecimal) {
+    this.set("totalBorrows", Value.fromBigDecimal(value));
+  }
+
+  get totalSupply(): BigDecimal {
+    let value = this.get("totalSupply");
+    return value.toBigDecimal();
+  }
+
+  set totalSupply(value: BigDecimal) {
+    this.set("totalSupply", Value.fromBigDecimal(value));
+  }
+
+  get suppliersCount(): i32 {
+    let value = this.get("suppliersCount");
+    return value.toI32();
+  }
+
+  set suppliersCount(value: i32) {
+    this.set("suppliersCount", Value.fromI32(value));
+  }
+
+  get borrowersCount(): i32 {
+    let value = this.get("borrowersCount");
+    return value.toI32();
+  }
+
+  set borrowersCount(value: i32) {
+    this.set("borrowersCount", Value.fromI32(value));
+  }
+
+  get underlyingPrice(): BigDecimal {
+    let value = this.get("underlyingPrice");
+    return value.toBigDecimal();
+  }
+
+  set underlyingPrice(value: BigDecimal) {
+    this.set("underlyingPrice", Value.fromBigDecimal(value));
+  }
+
+  get accrualBlockNumber(): BigInt | null {
+    let value = this.get("accrualBlockNumber");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set accrualBlockNumber(value: BigInt | null) {
+    if (value === null) {
+      this.unset("accrualBlockNumber");
+    } else {
+      this.set("accrualBlockNumber", Value.fromBigInt(value as BigInt));
+    }
+  }
+
+  get blockTimestamp(): BigInt {
+    let value = this.get("blockTimestamp");
+    return value.toBigInt();
+  }
+
+  set blockTimestamp(value: BigInt) {
+    this.set("blockTimestamp", Value.fromBigInt(value));
+  }
+
+  get borrowIndex(): BigDecimal {
+    let value = this.get("borrowIndex");
+    return value.toBigDecimal();
+  }
+
+  set borrowIndex(value: BigDecimal) {
+    this.set("borrowIndex", Value.fromBigDecimal(value));
+  }
+
+  get reserveFactor(): BigDecimal {
+    let value = this.get("reserveFactor");
+    return value.toBigDecimal();
+  }
+
+  set reserveFactor(value: BigDecimal) {
+    this.set("reserveFactor", Value.fromBigDecimal(value));
+  }
+
+  get underlyingPriceUSD(): BigDecimal {
+    let value = this.get("underlyingPriceUSD");
+    return value.toBigDecimal();
+  }
+
+  set underlyingPriceUSD(value: BigDecimal) {
+    this.set("underlyingPriceUSD", Value.fromBigDecimal(value));
+  }
+
+  get totalRewardsDistributed(): Array<BigDecimal> {
+    let value = this.get("totalRewardsDistributed");
+    return value.toBigDecimalArray();
+  }
+
+  set totalRewardsDistributed(value: Array<BigDecimal>) {
+    this.set("totalRewardsDistributed", Value.fromBigDecimalArray(value));
+  }
+
+  get totalFeesGenerated(): BigDecimal {
+    let value = this.get("totalFeesGenerated");
+    return value.toBigDecimal();
+  }
+
+  set totalFeesGenerated(value: BigDecimal) {
+    this.set("totalFeesGenerated", Value.fromBigDecimal(value));
+  }
+
+  get totalProtocolFeesGenerated(): BigDecimal {
+    let value = this.get("totalProtocolFeesGenerated");
+    return value.toBigDecimal();
+  }
+
+  set totalProtocolFeesGenerated(value: BigDecimal) {
+    this.set("totalProtocolFeesGenerated", Value.fromBigDecimal(value));
+  }
+}
 
 export class AccountMarketSnapshot extends Entity {
   constructor(id: string) {
@@ -1068,6 +1077,23 @@ export class AccountMarketSnapshot extends Entity {
     this.set("accountMarket", Value.fromString(value));
   }
 
+  get accrualBlockNumber(): BigInt | null {
+    let value = this.get("accrualBlockNumber");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set accrualBlockNumber(value: BigInt | null) {
+    if (value === null) {
+      this.unset("accrualBlockNumber");
+    } else {
+      this.set("accrualBlockNumber", Value.fromBigInt(value as BigInt));
+    }
+  }
+
   get blockNumber(): BigInt {
     let value = this.get("blockNumber");
     return value.toBigInt();
@@ -1077,22 +1103,67 @@ export class AccountMarketSnapshot extends Entity {
     this.set("blockNumber", Value.fromBigInt(value));
   }
 
-  get supply_amount(): BigDecimal {
-    let value = this.get("supply_amount");
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    return value.toBigInt();
+  }
+
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
+
+  get totalSupplyAmount(): BigDecimal {
+    let value = this.get("totalSupplyAmount");
     return value.toBigDecimal();
   }
 
-  set supply_amount(value: BigDecimal) {
-    this.set("supply_amount", Value.fromBigDecimal(value));
+  set totalSupplyAmount(value: BigDecimal) {
+    this.set("totalSupplyAmount", Value.fromBigDecimal(value));
   }
 
-  get borrow_amount(): BigDecimal {
-    let value = this.get("borrow_amount");
+  get storedBorrowBalance(): BigDecimal {
+    let value = this.get("storedBorrowBalance");
     return value.toBigDecimal();
   }
 
-  set borrow_amount(value: BigDecimal) {
-    this.set("borrow_amount", Value.fromBigDecimal(value));
+  set storedBorrowBalance(value: BigDecimal) {
+    this.set("storedBorrowBalance", Value.fromBigDecimal(value));
+  }
+
+  get borrowBalanceWithInterest(): BigDecimal {
+    let value = this.get("borrowBalanceWithInterest");
+    return value.toBigDecimal();
+  }
+
+  set borrowBalanceWithInterest(value: BigDecimal) {
+    this.set("borrowBalanceWithInterest", Value.fromBigDecimal(value));
+  }
+
+  get marketBorrowIndex(): BigDecimal {
+    let value = this.get("marketBorrowIndex");
+    return value.toBigDecimal();
+  }
+
+  set marketBorrowIndex(value: BigDecimal) {
+    this.set("marketBorrowIndex", Value.fromBigDecimal(value));
+  }
+
+  get accountBorrowIndex(): BigDecimal {
+    let value = this.get("accountBorrowIndex");
+    return value.toBigDecimal();
+  }
+
+  set accountBorrowIndex(value: BigDecimal) {
+    this.set("accountBorrowIndex", Value.fromBigDecimal(value));
+  }
+
+  get exchangeRate(): BigDecimal {
+    let value = this.get("exchangeRate");
+    return value.toBigDecimal();
+  }
+
+  set exchangeRate(value: BigDecimal) {
+    this.set("exchangeRate", Value.fromBigDecimal(value));
   }
 }
 
@@ -1308,6 +1379,15 @@ export class AccountCToken extends Entity {
 
   set storedBorrowBalance(value: BigDecimal) {
     this.set("storedBorrowBalance", Value.fromBigDecimal(value));
+  }
+
+  get snapshots(): Array<string> {
+    let value = this.get("snapshots");
+    return value.toStringArray();
+  }
+
+  set snapshots(value: Array<string>) {
+    this.set("snapshots", Value.fromStringArray(value));
   }
 }
 

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -17,8 +17,21 @@ dataSources:
       language: wasm/assemblyscript
       file: ./src/mappings/comptroller.ts
       entities:
+        - Account
+        - AccountCToken
+        - AccountCTokenTransaction
+        - AccountSnapshot
         - Comptroller
         - Market
+        - MarketDailySnapshot
+        - MarketHourlySnapshot
+        - BorrowEvent
+        - RepayEvent
+        - LiquidationEvent
+        - MintEvent
+        - RedeemEvent
+        - TransferEvent
+        - Token
       abis:
         - name: Comptroller
           file: ./abis/comptroller.json
@@ -43,10 +56,8 @@ dataSources:
           handler: handleNewCollateralFactor
         - event: NewLiquidationIncentive(uint256,uint256)
           handler: handleNewLiquidationIncentive
-        # - event: NewMaxAssets(uint256,uint256)
-        #   handler: handleNewMaxAssets
-        - event: NewPriceOracle(address,address)
-          handler: handleNewPriceOracle
+      blockHandlers:
+        - handler: handleNewBlock
 templates:
   - name: CToken
     kind: ethereum/contract

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -56,8 +56,6 @@ dataSources:
           handler: handleNewCollateralFactor
         - event: NewLiquidationIncentive(uint256,uint256)
           handler: handleNewLiquidationIncentive
-      blockHandlers:
-        - handler: handleNewBlock
 templates:
   - name: CToken
     kind: ethereum/contract

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -20,7 +20,7 @@ dataSources:
         - Account
         - AccountCToken
         - AccountCTokenTransaction
-        - AccountSnapshot
+        - AccountMarketSnapshot
         - Comptroller
         - Market
         - MarketDailySnapshot

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -10,7 +10,7 @@ dataSources:
     source:
       address: "0x486Af39519B4Dc9a7fCcd318217352830E8AD9b4"
       abi: Comptroller
-      startBlock: 3046884 # first MarketListed event on https://snowtrace.io/block/3046885
+      startBlock: 3046285 # comptroller created on https://snowtrace.io/block/3046286
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4


### PR DESCRIPTION
Implement Market and AccountMarket snapshots to have historical information.

Market snapshots will be hourly and daily (every new event updates the next snapshot so each snapshot contains the most recent value prior to that timestamp) while AccountMarket snapshots are "indexed" by block number so in case of a reorg the snapshot will be rewritten.

The AccountMarket snapshot fulfills the purpose of telling on every block which accounts had open positions on supply and borrows.